### PR TITLE
Adicionar _redirects para o SPA

### DIFF
--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,0 +1,3 @@
+http://smae.appcivico.com/* https://smae.appcivico.com/:splat 301!
+
+/*                /index.html 200


### PR DESCRIPTION
Adicionar redirect para que rotas como /usuarios/novo sejam sempre direcionadas para o index.html e forçar o SSL