### PR TITLE
S20.16PS013 - Ajusta erro na edição de meta/iniciativa/atv

### DIFF
--- a/frontend/src/views/metas/AddEdit.vue
+++ b/frontend/src/views/metas/AddEdit.vue
@@ -151,7 +151,7 @@ const valoresIniciais = computed(() => ({
     : [],
 }));
 
-async function onSubmit(values) {
+async function onSubmit(_, { controlledValues: values }) {
   try {
     const er = [];
 

--- a/frontend/src/views/metas/AddEditAtividade.vue
+++ b/frontend/src/views/metas/AddEditAtividade.vue
@@ -120,7 +120,7 @@ const schema = Yup.object().shape({
   compoe_indicador_iniciativa: Yup.string().nullable(),
 });
 
-async function onSubmit(values) {
+async function onSubmit(_, { controlledValues: values }) {
   try {
     const er = [];
     values.orgaos_participantes = unref(orgaosParticipantes);

--- a/frontend/src/views/metas/AddEditIniciativa.vue
+++ b/frontend/src/views/metas/AddEditIniciativa.vue
@@ -122,7 +122,7 @@ const schema = Yup.object().shape({
   compoe_indicador_meta: Yup.string().nullable(),
 });
 
-async function onSubmit(values) {
+async function onSubmit(_, { controlledValues: values }) {
   try {
     const er = [];
     values.orgaos_participantes = unref(orgaos_participantes);
@@ -169,6 +169,7 @@ async function onSubmit(values) {
     alertStore.error(error);
   }
 }
+
 async function checkDelete(id) {
   if (id) {
     if (singleIniciativa.value.id == id) {


### PR DESCRIPTION
Muda a função de submit do meta/iniciativa/atividade para usar o `controlledValues`, dessa forma evitando de mandar dados "sujos" que vieram do back