### PR TITLE
Bugfix/s20.16 ps017

### DIFF
--- a/frontend/src/_less/_base.less
+++ b/frontend/src/_less/_base.less
@@ -1395,6 +1395,15 @@ p {
   position: relative;
   padding: .5rem 0;
 
+  &::before {
+    content: "";
+    position: absolute;
+    top: -1rem;
+    right: -1rem;
+    bottom: -1rem;
+    left: -1rem;
+  }
+
   ul {
     position: absolute;
     top: 100%;
@@ -1433,6 +1442,7 @@ p {
       a {
         .t14;
         .w700;
+        display: block;
         color: @primary;
 
         &:hover {
@@ -1440,7 +1450,7 @@ p {
         }
       }
 
-      +li {
+      + li {
         margin-top: .5em;
       }
     }

--- a/frontend/src/components/EsperarEntrarNaTela.vue
+++ b/frontend/src/components/EsperarEntrarNaTela.vue
@@ -5,11 +5,14 @@
       v-if="!entrouNaTela"
       ref="elementoTemporario"
       class="marcador-de-posicao"
+      v-bind="$attrs"
     >
       <slot
         v-if="$slots.marcadorDePosicao"
         name="conteudoDoMarcadorDePosicao"
-      />
+      >
+        <LoadingComponent />
+      </slot>
     </component>
     <slot
       v-else-if="entrouNaTela"
@@ -19,6 +22,10 @@
 <script lang="ts" setup>
 import isValidHtmlTag from '@/helpers/isValidHtmlTag';
 import { defineProps, onMounted, ref } from 'vue';
+
+defineOptions({
+  inheritAttrs: false,
+});
 
 const emit = defineEmits(['entrouNaTela']);
 
@@ -53,3 +60,8 @@ onMounted(() => {
   }
 });
 </script>
+<style scoped>
+.marcador-de-posicao + .marcador-de-posicao {
+  min-height: 2rem;
+}
+</style>

--- a/frontend/src/components/metas/EvolucaoDeMetaIniciativaAtividade.vue
+++ b/frontend/src/components/metas/EvolucaoDeMetaIniciativaAtividade.vue
@@ -1,0 +1,227 @@
+<template>
+  <article
+    class="board_variavel mb2"
+    :aria-busy="haChamadasPendentes"
+  >
+    <header class="p1">
+      <div class="flex center g2">
+        <div class="flex center f1">
+          <svg
+            width="28"
+            height="28"
+            viewBox="0 0 28 28"
+            class="f0"
+            color="#8EC122"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24.9091 0.36377H3.09091C2.36759 0.36377 1.6739 0.651104
+              1.16244 1.16257C0.650975 1.67403 0.36364 2.36772 0.36364
+              3.09104V24.9092C0.36364 25.6325 0.650975 26.3262 1.16244
+              26.8377C1.6739 27.3492 2.36759 27.6365 3.09091
+              27.6365H24.9091C25.6324 27.6365 26.3261 27.3492 26.8376
+              26.8377C27.349 26.3262 27.6364 25.6325 27.6364
+              24.9092V3.09104C27.6364 2.36772 27.349 1.67403 26.8376
+              1.16257C26.3261 0.651104 25.6324 0.36377 24.9091
+              0.36377ZM24.9091 3.09104V8.54559H24.3636L22.1818
+              10.7274L16.5909 5.1365L11.1364 11.9547L7.18182 8.00012L3.90909
+              11.2729H3.09091V3.09104H24.9091ZM3.09091
+              24.9092V14.0001H5L7.18182 11.8183L11.4091 16.0456L16.8636
+              9.22741L22.1818 14.5456L25.5909
+              11.2729H24.9091V24.9092H3.09091Z"
+              fill="currentColor"
+            />
+            <path
+              d="M7.18182 19.4547H4.45455V23.5456H7.18182V19.4547Z"
+              fill="currentColor"
+            />
+            <path
+              d="M12.6364 18.091H9.90909V23.5456H12.6364V18.091Z"
+              fill="currentColor"
+            />
+            <path
+              d="M18.0909 15.3638H15.3636V23.5456H18.0909V15.3638Z"
+              fill="currentColor"
+            />
+            <path
+              d="M23.5455 18.091H20.8182V23.5456H23.5455V18.091Z"
+              fill="currentColor"
+            />
+          </svg>
+          <h2 class="mt1 mb1 ml1 f1">
+            {{ variavel.codigo }} - {{ variavel.titulo }}
+          </h2>
+          <div
+            v-if="variavel.suspendida"
+            class="tipinfo left"
+          >
+            <svg
+              width="24"
+              height="24"
+              color="#F2890D"
+            ><use xlink:href="#i_alert" /></svg><div>
+              Suspensa do monitoramento físico em {{ dateToField(variavel.suspendida_em) }}
+            </div>
+          </div>
+        </div>
+
+        <div
+          v-if="$route.meta.entidadeMãe === 'pdm'
+            && !variavel.etapa
+            && temPermissãoPara([
+              'CadastroMeta.administrador_no_pdm',
+              'CadastroMetaPS.administrador_no_pdm'
+            ])"
+          class="f0 dropbtn right"
+        >
+          <span class="tamarelo"><svg
+            width="20"
+            height="20"
+          ><use xlink:href="#i_more" /></svg></span>
+          <ul>
+            <li>
+              <SmaeLink
+                :to="`${parentLink}/evolucao/${indicador.id}/variaveis/${variavel.id}`"
+                class="tprimary"
+              >
+                Editar variável
+              </SmaeLink>
+            </li>
+            <li>
+              <SmaeLink
+                :to="`${parentLink}/evolucao/${indicador.id}/variaveis/${variavel.id}/valores`"
+                class="tprimary"
+              >
+                Valores previstos
+              </SmaeLink>
+            </li>
+            <li>
+              <SmaeLink
+                v-if="temPermissãoPara(['CadastroPessoa.administrador'])"
+                :to="`${parentLink}/evolucao/${indicador.id}/variaveis/${variavel.id}/retroativos`"
+                class="tprimary"
+              >
+                Valores realizados retroativos
+              </SmaeLink>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <LoadingComponent v-if="haChamadasPendentes" />
+
+      <EvolucaoGraph
+        v-else
+        :dataserie="Valores[(variavel.id as keyof {})]"
+        :tem-categorica="!!variavel.variavel_categorica_id"
+      />
+    </header>
+
+    <section>
+      <div class="tablepreinfo">
+        <div class="flex spacebetween">
+          <div class="flex center">
+            <div class="t12 lh1 w700 uc tc400">
+              Previsto X Realizado
+            </div>
+            <div class="tipinfo ml1">
+              <svg
+                width="20"
+                height="20"
+              ><use xlink:href="#i_i" /></svg><div>
+                Indicador calculado pelo média móvel das variáveis
+              </div>
+            </div>
+          </div>
+          <!-- <div>
+                <a class="addlink"><svg width="20"
+                  height="20"><use xlink:href="#i_+"></use></svg><span>
+                  Adicionar período
+                </span></a>
+            </div> -->
+        </div>
+      </div>
+      <table class="tablemain">
+        <thead>
+          <tr>
+            <th>
+              Mês/Ano
+            </th>
+            <th>
+              Previsto Mensal
+            </th>
+            <th>
+              Realizado Mensal
+            </th>
+            <th>
+              Previsto Acumulado
+            </th>
+            <th>
+              Realizado Acumulado
+            </th>
+            <th />
+          </tr>
+        </thead>
+
+        <tbody v-if="haChamadasPendentes">
+          <tr>
+            <td colspan="6">
+              <LoadingComponent class="horizontal" />
+            </td>
+          </tr>
+        </tbody>
+        <GruposDeSerie
+          v-else
+          :g="Valores[(variavel.id as keyof {})]"
+          variavel="true"
+          :tem-variavel-acumulada="!!variavel.acumulativa"
+        />
+      </table>
+    </section>
+  </article>
+</template>
+<script lang="ts" setup>
+import EvolucaoGraph from '@/components/EvolucaoGraph.vue';
+import GruposDeSerie from '@/components/metas/GruposDeSerie.vue';
+import dateToField from '@/helpers/dateToField';
+import { useAuthStore } from '@/stores/auth.store';
+import { useVariaveisStore } from '@/stores/variaveis.store';
+import type { Indicador } from '@back/indicador/entities/indicador.entity';
+import type { VariavelItemDto } from '@back/variavel/entities/variavel.entity';
+import { storeToRefs } from 'pinia';
+import { ref, watch, type PropType } from 'vue';
+
+const authStore = useAuthStore();
+const { temPermissãoPara } = authStore;
+
+const props = defineProps({
+  indicador: {
+    type: Object as PropType<Indicador>,
+    default: () => ({}),
+    required: true,
+  },
+  variavel: {
+    type: Object as PropType<VariavelItemDto>,
+    required: true,
+  },
+  parentLink: {
+    type: String,
+    required: true,
+  },
+});
+
+const VariaveisStore = useVariaveisStore();
+const { Valores } = storeToRefs(VariaveisStore);
+
+const haChamadasPendentes = ref(false);
+
+watch(() => props.variavel.id, () => {
+  if (props.variavel.id) {
+    haChamadasPendentes.value = true;
+    VariaveisStore.getValores(props.variavel.id, { leitura: true })
+      .then(() => {
+        haChamadasPendentes.value = false;
+      });
+  }
+}, { immediate: true });
+</script>

--- a/frontend/src/router/metas.js
+++ b/frontend/src/router/metas.js
@@ -279,55 +279,57 @@ export default {
       component: SingleEvolucao,
       meta: {
         títuloParaMenu: 'Evolução',
+        rotaPrescindeDeChave: true,
         rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
       },
-    },
-    {
-      path: ':meta_id/evolucao/:indicador_id',
-      component: SingleEvolucao,
-      meta: {
-        rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
-      },
-    },
-    {
-      path: ':meta_id/evolucao/:indicador_id/variaveis/novo',
-      component: SingleEvolucao,
-      props: { group: 'variaveis' },
-      meta: {
-        rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
-      },
-    },
-    {
-      path: ':meta_id/evolucao/:indicador_id/variaveis/novo/:copy_id',
-      component: SingleEvolucao,
-      props: { group: 'variaveis' },
-      meta: {
-        rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
-      },
-    },
-    {
-      path: ':meta_id/evolucao/:indicador_id/variaveis/:var_id',
-      component: SingleEvolucao,
-      props: { group: 'variaveis' },
-      meta: {
-        rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
-      },
-    },
-    {
-      path: ':meta_id/evolucao/:indicador_id/variaveis/:var_id/valores',
-      component: SingleEvolucao,
-      props: { group: 'valores' },
-      meta: {
-        rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
-      },
-    },
-    {
-      path: ':meta_id/evolucao/:indicador_id/variaveis/:var_id/retroativos',
-      component: SingleEvolucao,
-      props: { group: 'retroativos' },
-      meta: {
-        rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
-      },
+      children: [
+        {
+          path: ':indicador_id',
+          meta: {
+            rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
+          },
+        },
+        {
+          path: ':indicador_id/variaveis/novo',
+          meta: {
+            group: 'variaveis',
+            rotaPrescindeDeChave: true,
+            rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
+          },
+        },
+        {
+          path: ':indicador_id/variaveis/novo/:copy_id',
+          meta: {
+            group: 'variaveis',
+            rotaPrescindeDeChave: true,
+            rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
+          },
+        },
+        {
+          path: ':indicador_id/variaveis/:var_id',
+          meta: {
+            group: 'variaveis',
+            rotaPrescindeDeChave: true,
+            rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
+          },
+        },
+        {
+          path: ':indicador_id/variaveis/:var_id/valores',
+          meta: {
+            group: 'valores',
+            rotaPrescindeDeChave: true,
+            rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
+          },
+        },
+        {
+          path: ':indicador_id/variaveis/:var_id/retroativos',
+          meta: {
+            group: 'retroativos',
+            rotaPrescindeDeChave: true,
+            rotasParaMenuSecundário: rotasParaMenuSecundário('meta'),
+          },
+        },
+      ],
     },
     {
       path: ':meta_id/cronograma',
@@ -717,55 +719,57 @@ export default {
           component: SingleEvolucao,
           meta: {
             títuloParaMenu: 'Evolução',
+            rotaPrescindeDeChave: true,
             rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
           },
-        },
-        {
-          path: ':iniciativa_id/evolucao/:indicador_id',
-          component: SingleEvolucao,
-          meta: {
-            rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-          },
-        },
-        {
-          path: ':iniciativa_id/evolucao/:indicador_id/variaveis/novo',
-          component: SingleEvolucao,
-          props: { group: 'variaveis' },
-          meta: {
-            rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-          },
-        },
-        {
-          path: ':iniciativa_id/evolucao/:indicador_id/variaveis/novo/:copy_id',
-          component: SingleEvolucao,
-          props: { group: 'variaveis' },
-          meta: {
-            rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-          },
-        },
-        {
-          path: ':iniciativa_id/evolucao/:indicador_id/variaveis/:var_id',
-          component: SingleEvolucao,
-          props: { group: 'variaveis' },
-          meta: {
-            rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-          },
-        },
-        {
-          path: ':iniciativa_id/evolucao/:indicador_id/variaveis/:var_id/valores',
-          component: SingleEvolucao,
-          props: { group: 'valores' },
-          meta: {
-            rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-          },
-        },
-        {
-          path: ':iniciativa_id/evolucao/:indicador_id/variaveis/:var_id/retroativos',
-          component: SingleEvolucao,
-          props: { group: 'retroativos' },
-          meta: {
-            rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-          },
+          children: [
+            {
+              path: ':indicador_id',
+              meta: {
+                rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+              },
+            },
+            {
+              path: ':indicador_id/variaveis/novo',
+              meta: {
+                group: 'variaveis',
+                rotaPrescindeDeChave: true,
+                rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+              },
+            },
+            {
+              path: ':indicador_id/variaveis/novo/:copy_id',
+              meta: {
+                group: 'variaveis',
+                rotaPrescindeDeChave: true,
+                rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+              },
+            },
+            {
+              path: ':indicador_id/variaveis/:var_id',
+              meta: {
+                group: 'variaveis',
+                rotaPrescindeDeChave: true,
+                rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+              },
+            },
+            {
+              path: ':indicador_id/variaveis/:var_id/valores',
+              meta: {
+                group: 'valores',
+                rotaPrescindeDeChave: true,
+                rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+              },
+            },
+            {
+              path: ':indicador_id/variaveis/:var_id/retroativos',
+              meta: {
+                group: 'retroativos',
+                rotaPrescindeDeChave: true,
+                rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+              },
+            },
+          ],
         },
         {
           path: ':iniciativa_id/cronograma',
@@ -1027,55 +1031,57 @@ export default {
               component: SingleEvolucao,
               meta: {
                 títuloParaMenu: 'Evolução',
+                rotaPrescindeDeChave: true,
                 rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
               },
-            },
-            {
-              path: ':atividade_id/evolucao/:indicador_id',
-              component: SingleEvolucao,
-              meta: {
-                rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-              },
-            },
-            {
-              path: ':atividade_id/evolucao/:indicador_id/variaveis/novo',
-              component: SingleEvolucao,
-              props: { group: 'variaveis' },
-              meta: {
-                rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-              },
-            },
-            {
-              path: ':atividade_id/evolucao/:indicador_id/variaveis/novo/:copy_id',
-              component: SingleEvolucao,
-              props: { group: 'variaveis' },
-              meta: {
-                rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-              },
-            },
-            {
-              path: ':atividade_id/evolucao/:indicador_id/variaveis/:var_id',
-              component: SingleEvolucao,
-              props: { group: 'variaveis' },
-              meta: {
-                rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-              },
-            },
-            {
-              path: ':atividade_id/evolucao/:indicador_id/variaveis/:var_id/valores',
-              component: SingleEvolucao,
-              props: { group: 'valores' },
-              meta: {
-                rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-              },
-            },
-            {
-              path: ':atividade_id/evolucao/:indicador_id/variaveis/:var_id/retroativos',
-              component: SingleEvolucao,
-              props: { group: 'retroativos' },
-              meta: {
-                rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-              },
+              children: [
+                {
+                  path: ':indicador_id',
+                  meta: {
+                    rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                  },
+                },
+                {
+                  path: ':indicador_id/variaveis/novo',
+                  meta: {
+                    group: 'variaveis',
+                    rotaPrescindeDeChave: true,
+                    rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                  },
+                },
+                {
+                  path: ':indicador_id/variaveis/novo/:copy_id',
+                  meta: {
+                    group: 'variaveis',
+                    rotaPrescindeDeChave: true,
+                    rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                  },
+                },
+                {
+                  path: ':indicador_id/variaveis/:var_id',
+                  meta: {
+                    group: 'variaveis',
+                    rotaPrescindeDeChave: true,
+                    rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                  },
+                },
+                {
+                  path: ':indicador_id/variaveis/:var_id/valores',
+                  meta: {
+                    group: 'valores',
+                    rotaPrescindeDeChave: true,
+                    rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                  },
+                },
+                {
+                  path: ':indicador_id/variaveis/:var_id/retroativos',
+                  meta: {
+                    group: 'retroativos',
+                    rotaPrescindeDeChave: true,
+                    rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                  },
+                },
+              ],
             },
             {
               path: ':atividade_id/cronograma',

--- a/frontend/src/router/metasDePlanosSetoriais.js
+++ b/frontend/src/router/metasDePlanosSetoriais.js
@@ -316,58 +316,55 @@ export default [
     component: SingleEvolucao,
     meta: {
       títuloParaMenu: 'Evolução',
+      rotaPrescindeDeChave: true,
       rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
     },
-  },
-  {
-    path: ':meta_id/evolucao/:indicador_id',
-    component: SingleEvolucao,
-    name: 'planoSetorial:evolucaoDoIndicador',
-    meta: {
-      rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
-    },
-  },
-  {
-    path: ':meta_id/evolucao/:indicador_id/variaveis/novo',
-    component: SingleEvolucao,
-    props: { group: 'variaveis' },
-    meta: {
-      rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
-    },
-  },
-  {
-    path: ':meta_id/evolucao/:indicador_id/variaveis/novo/:copy_id',
-    component: SingleEvolucao,
-    props: { group: 'variaveis' },
-    meta: {
-      rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
-    },
-  },
-  {
-    path: ':meta_id/evolucao/:indicador_id/variaveis/:var_id',
-    component: SingleEvolucao,
-    props: { group: 'variaveis' },
-    meta: {
-      rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
-    },
-  },
-  {
-    path: ':meta_id/evolucao/:indicador_id/variaveis/:var_id/valores',
-    component: SingleEvolucao,
-    props: { group: 'valores' },
-    meta: {
-      rotaDeEscape: 'planoSetorial:evolucaoDoIndicador',
-      rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
-    },
-  },
-  {
-    path: ':meta_id/evolucao/:indicador_id/variaveis/:var_id/retroativos',
-    component: SingleEvolucao,
-    props: { group: 'retroativos' },
-    meta: {
-      rotaDeEscape: 'planoSetorial:evolucaoDoIndicador',
-      rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
-    },
+    children: [
+      {
+        path: ':indicador_id',
+        name: 'planoSetorial:evolucaoDoIndicador',
+        meta: {
+          rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
+        },
+      },
+      {
+        path: ':indicador_id/variaveis/novo',
+        meta: {
+          group: 'variaveis',
+          rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
+        },
+      },
+      {
+        path: ':indicador_id/variaveis/novo/:copy_id',
+        meta: {
+          group: 'variaveis',
+          rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
+        },
+      },
+      {
+        path: ':indicador_id/variaveis/:var_id',
+        meta: {
+          group: 'variaveis',
+          rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
+        },
+      },
+      {
+        path: ':indicador_id/variaveis/:var_id/valores',
+        meta: {
+          group: 'valores',
+          rotaDeEscape: 'planoSetorial:evolucaoDoIndicador',
+          rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
+        },
+      },
+      {
+        path: ':indicador_id/variaveis/:var_id/retroativos',
+        meta: {
+          group: 'retroativos',
+          rotaDeEscape: 'planoSetorial:evolucaoDoIndicador',
+          rotasParaMenuSecundário: () => rotasParaMenuSecundário('meta', usePlanosSetoriaisStore().orcamentosDisponiveisNoPlanoEmFoco),
+        },
+      },
+    ],
   },
   {
     path: ':meta_id/cronograma',
@@ -767,58 +764,55 @@ export default [
         component: SingleEvolucao,
         meta: {
           títuloParaMenu: 'Evolução',
+          rotaPrescindeDeChave: true,
           rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
         },
-      },
-      {
-        path: ':iniciativa_id/evolucao/:indicador_id',
-        component: SingleEvolucao,
-        name: 'planoSetorial:evoluçãoDoIndicadorDaIniciativa',
-        meta: {
-          rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-        },
-      },
-      {
-        path: ':iniciativa_id/evolucao/:indicador_id/variaveis/novo',
-        component: SingleEvolucao,
-        props: { group: 'variaveis' },
-        meta: {
-          rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-        },
-      },
-      {
-        path: ':iniciativa_id/evolucao/:indicador_id/variaveis/novo/:copy_id',
-        component: SingleEvolucao,
-        props: { group: 'variaveis' },
-        meta: {
-          rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-        },
-      },
-      {
-        path: ':iniciativa_id/evolucao/:indicador_id/variaveis/:var_id',
-        component: SingleEvolucao,
-        props: { group: 'variaveis' },
-        meta: {
-          rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-        },
-      },
-      {
-        path: ':iniciativa_id/evolucao/:indicador_id/variaveis/:var_id/valores',
-        component: SingleEvolucao,
-        props: { group: 'valores' },
-        meta: {
-          rotaDeEscape: 'planoSetorial:evoluçãoDoIndicadorDaIniciativa',
-          rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-        },
-      },
-      {
-        path: ':iniciativa_id/evolucao/:indicador_id/variaveis/:var_id/retroativos',
-        component: SingleEvolucao,
-        props: { group: 'retroativos' },
-        meta: {
-          rotaDeEscape: 'planoSetorial:evoluçãoDoIndicadorDaIniciativa',
-          rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
-        },
+        children: [
+          {
+            path: ':indicador_id',
+            name: 'planoSetorial:evoluçãoDoIndicadorDaIniciativa',
+            meta: {
+              rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+            },
+          },
+          {
+            path: ':indicador_id/variaveis/novo',
+            meta: {
+              group: 'variaveis',
+              rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+            },
+          },
+          {
+            path: ':indicador_id/variaveis/novo/:copy_id',
+            meta: {
+              group: 'variaveis',
+              rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+            },
+          },
+          {
+            path: ':indicador_id/variaveis/:var_id',
+            meta: {
+              group: 'variaveis',
+              rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+            },
+          },
+          {
+            path: ':indicador_id/variaveis/:var_id/valores',
+            meta: {
+              group: 'valores',
+              rotaDeEscape: 'planoSetorial:evoluçãoDoIndicadorDaIniciativa',
+              rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+            },
+          },
+          {
+            path: ':indicador_id/variaveis/:var_id/retroativos',
+            meta: {
+              group: 'retroativos',
+              rotaDeEscape: 'planoSetorial:evoluçãoDoIndicadorDaIniciativa',
+              rotasParaMenuSecundário: rotasParaMenuSecundário('iniciativa'),
+            },
+          },
+        ],
       },
       {
         path: ':iniciativa_id/cronograma',
@@ -1086,58 +1080,55 @@ export default [
             component: SingleEvolucao,
             meta: {
               títuloParaMenu: 'Evolução',
+              rotaPrescindeDeChave: true,
               rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
             },
-          },
-          {
-            path: ':atividade_id/evolucao/:indicador_id',
-            component: SingleEvolucao,
-            name: 'planoSetorial:evoluçãoDoIndicadorDaAtividade',
-            meta: {
-              rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-            },
-          },
-          {
-            path: ':atividade_id/evolucao/:indicador_id/variaveis/novo',
-            component: SingleEvolucao,
-            props: { group: 'variaveis' },
-            meta: {
-              rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-            },
-          },
-          {
-            path: ':atividade_id/evolucao/:indicador_id/variaveis/novo/:copy_id',
-            component: SingleEvolucao,
-            props: { group: 'variaveis' },
-            meta: {
-              rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-            },
-          },
-          {
-            path: ':atividade_id/evolucao/:indicador_id/variaveis/:var_id',
-            component: SingleEvolucao,
-            props: { group: 'variaveis' },
-            meta: {
-              rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-            },
-          },
-          {
-            path: ':atividade_id/evolucao/:indicador_id/variaveis/:var_id/valores',
-            component: SingleEvolucao,
-            props: { group: 'valores' },
-            meta: {
-              rotaDeEscape: 'planoSetorial:evoluçãoDoIndicadorDaAtividade',
-              rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-            },
-          },
-          {
-            path: ':atividade_id/evolucao/:indicador_id/variaveis/:var_id/retroativos',
-            component: SingleEvolucao,
-            props: { group: 'retroativos' },
-            meta: {
-              rotaDeEscape: 'planoSetorial:evoluçãoDoIndicadorDaAtividade',
-              rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
-            },
+            children: [
+              {
+                path: ':indicador_id',
+                name: 'planoSetorial:evoluçãoDoIndicadorDaAtividade',
+                meta: {
+                  rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                },
+              },
+              {
+                path: ':indicador_id/variaveis/novo',
+                meta: {
+                  group: 'variaveis',
+                  rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                },
+              },
+              {
+                path: ':indicador_id/variaveis/novo/:copy_id',
+                meta: {
+                  group: 'variaveis',
+                  rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                },
+              },
+              {
+                path: ':indicador_id/variaveis/:var_id',
+                meta: {
+                  group: 'variaveis',
+                  rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                },
+              },
+              {
+                path: ':indicador_id/variaveis/:var_id/valores',
+                meta: {
+                  group: 'valores',
+                  rotaDeEscape: 'planoSetorial:evoluçãoDoIndicadorDaAtividade',
+                  rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                },
+              },
+              {
+                path: ':indicador_id/variaveis/:var_id/retroativos',
+                meta: {
+                  group: 'retroativos',
+                  rotaDeEscape: 'planoSetorial:evoluçãoDoIndicadorDaAtividade',
+                  rotasParaMenuSecundário: rotasParaMenuSecundário('atividade'),
+                },
+              },
+            ],
           },
           {
             path: ':atividade_id/cronograma',

--- a/frontend/src/views/metas/SingleEvolucao.vue
+++ b/frontend/src/views/metas/SingleEvolucao.vue
@@ -1,9 +1,10 @@
 <script setup>
+import EsperarEntrarNaTela from '@/components/EsperarEntrarNaTela.vue';
 import EvolucaoGraph from '@/components/EvolucaoGraph.vue';
+import EvolucaoDeMetaIniciativaAtividade from '@/components/metas/EvolucaoDeMetaIniciativaAtividade.vue';
 import GruposDeSerie from '@/components/metas/GruposDeSerie.vue';
 import MigalhasDeMetas from '@/components/metas/MigalhasDeMetas.vue';
 import SmallModal from '@/components/SmallModal.vue';
-import dateToField from '@/helpers/dateToField';
 import { useAuthStore } from '@/stores/auth.store';
 import { useIndicadoresStore } from '@/stores/indicadores.store';
 import { useMetasStore } from '@/stores/metas.store';
@@ -35,7 +36,7 @@ const parentField = atividadeId ? 'atividade_id' : iniciativaId ? 'iniciativa_id
 // eslint-disable-next-line no-nested-ternary
 const parentLabel = ref(atividadeId ? '-' : iniciativaId ? '-' : metaId ? 'Meta' : false);
 
-const parentlink = (() => {
+const parentLink = (() => {
   let baseLink = window.location.origin;
 
   if (metaId) {
@@ -52,8 +53,6 @@ const parentlink = (() => {
 
   return baseLink;
 })();
-
-const ehPlanoSetorial = computed(() => route.meta.entidadeMãe === 'planoSetorial');
 
 const dialogoAtivo = computed(() => {
   switch (props.group) {
@@ -78,7 +77,7 @@ const IndicadoresStore = useIndicadoresStore();
 const { tempIndicadores, ValoresInd } = storeToRefs(IndicadoresStore);
 
 const VariaveisStore = useVariaveisStore();
-const { Variaveis, Valores } = storeToRefs(VariaveisStore);
+const { Variaveis } = storeToRefs(VariaveisStore);
 
 (async () => {
   // mantendo comportamento legado
@@ -89,12 +88,6 @@ const { Variaveis, Valores } = storeToRefs(VariaveisStore);
   if (tempIndicadores.value[0]?.id) {
     IndicadoresStore.getValores(tempIndicadores.value[0]?.id);
     await VariaveisStore.getAll(tempIndicadores.value[0]?.id);
-  }
-
-  if (Variaveis.value[tempIndicadores.value[0]?.id]) {
-    Variaveis.value[tempIndicadores.value[0]?.id].forEach((x) => {
-      VariaveisStore.getValores(x.id, { leitura: true });
-    });
   }
 })();
 </script>
@@ -180,7 +173,7 @@ const { Variaveis, Valores } = storeToRefs(VariaveisStore);
                   'CadastroMeta.administrador_no_pdm',
                   'CadastroMetaPS.administrador_no_pdm'
                 ])"
-                :to="`${parentlink}/indicadores/${ind.id}`"
+                :to="`${parentLink}/indicadores/${ind.id}`"
                 class="tprimary"
               >
                 <svg
@@ -243,172 +236,20 @@ const { Variaveis, Valores } = storeToRefs(VariaveisStore);
           Variáveis
         </div>
         <hr class="mb2">
+
         <template v-if="!Variaveis[ind.id]?.loading">
-          <div
+          <EsperarEntrarNaTela
             v-for="v in Variaveis[ind.id]"
             :key="v.id"
-            class="board_variavel mb2"
           >
-            <header class="p1">
-              <div class="flex center g2">
-                <div class="flex center f1">
-                  <svg
-                    width="28"
-                    height="28"
-                    viewBox="0 0 28 28"
-                    class="f0"
-                    color="#8EC122"
-                    xmlns="http://www.w3.org/2000/svg"
-                  > <path
-                    d="M24.9091 0.36377H3.09091C2.36759 0.36377 1.6739 0.651104
-                    1.16244 1.16257C0.650975 1.67403 0.36364 2.36772 0.36364
-                    3.09104V24.9092C0.36364 25.6325 0.650975 26.3262 1.16244
-                    26.8377C1.6739 27.3492 2.36759 27.6365 3.09091
-                    27.6365H24.9091C25.6324 27.6365 26.3261 27.3492 26.8376
-                    26.8377C27.349 26.3262 27.6364 25.6325 27.6364
-                    24.9092V3.09104C27.6364 2.36772 27.349 1.67403 26.8376
-                    1.16257C26.3261 0.651104 25.6324 0.36377 24.9091
-                    0.36377ZM24.9091 3.09104V8.54559H24.3636L22.1818
-                    10.7274L16.5909 5.1365L11.1364 11.9547L7.18182 8.00012L3.90909
-                    11.2729H3.09091V3.09104H24.9091ZM3.09091
-                    24.9092V14.0001H5L7.18182 11.8183L11.4091 16.0456L16.8636
-                    9.22741L22.1818 14.5456L25.5909
-                    11.2729H24.9091V24.9092H3.09091Z"
-                    fill="currentColor"
-                  /> <path
-                    d="M7.18182 19.4547H4.45455V23.5456H7.18182V19.4547Z"
-                    fill="currentColor"
-                  /> <path
-                    d="M12.6364 18.091H9.90909V23.5456H12.6364V18.091Z"
-                    fill="currentColor"
-                  /> <path
-                    d="M18.0909 15.3638H15.3636V23.5456H18.0909V15.3638Z"
-                    fill="currentColor"
-                  /> <path
-                    d="M23.5455 18.091H20.8182V23.5456H23.5455V18.091Z"
-                    fill="currentColor"
-                  /> </svg>
-                  <h2 class="mt1 mb1 ml1 f1">
-                    {{ v.codigo }} - {{ v.titulo }}
-                  </h2>
-                  <div
-                    v-if="v.suspendida"
-                    class="tipinfo left"
-                  >
-                    <svg
-                      width="24"
-                      height="24"
-                      color="#F2890D"
-                    ><use xlink:href="#i_alert" /></svg><div>
-                      Suspensa do monitoramento físico em {{ dateToField(v.suspendida_em) }}
-                    </div>
-                  </div>
-                </div>
-
-                <div
-                  v-if="
-                    !ehPlanoSetorial
-                      && !v.etapa
-                      && temPermissãoPara([
-                        'CadastroMeta.administrador_no_pdm',
-                        'CadastroMetaPS.administrador_no_pdm'
-                      ])
-                  "
-                  class="f0 dropbtn right"
-                >
-                  <span class="tamarelo"><svg
-                    width="20"
-                    height="20"
-                  ><use xlink:href="#i_more" /></svg></span>
-                  <ul>
-                    <li>
-                      <SmaeLink
-                        :to="`${parentlink}/evolucao/${ind.id}/variaveis/${v.id}`"
-                        class="tprimary"
-                      >
-                        Editar variável
-                      </SmaeLink>
-                    </li>
-                    <li>
-                      <SmaeLink
-                        :to="`${parentlink}/evolucao/${ind.id}/variaveis/${v.id}/valores`"
-                        class="tprimary"
-                      >
-                        Valores previstos
-                      </SmaeLink>
-                    </li>
-                    <li>
-                      <SmaeLink
-                        v-if="temPermissãoPara(['CadastroPessoa.administrador'])"
-                        :to="`${parentlink}/evolucao/${ind.id}/variaveis/${v.id}/retroativos`"
-                        class="tprimary"
-                      >
-                        Valores realizados retroativos
-                      </SmaeLink>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-              <EvolucaoGraph
-                :dataserie="Valores[v.id]"
-                :tem-categorica="!!v.variavel_categorica_id"
-              />
-            </header>
-            <div>
-              <div class="tablepreinfo">
-                <div class="flex spacebetween">
-                  <div class="flex center">
-                    <div class="t12 lh1 w700 uc tc400">
-                      Previsto X Realizado
-                    </div>
-                    <div class="tipinfo ml1">
-                      <svg
-                        width="20"
-                        height="20"
-                      ><use xlink:href="#i_i" /></svg><div>
-                        Indicador calculado pelo média móvel das variáveis
-                      </div>
-                    </div>
-                  </div>
-                  <!-- <div>
-                        <a class="addlink"><svg width="20"
-                          height="20"><use xlink:href="#i_+"></use></svg><span>
-                          Adicionar período
-                        </span></a>
-                    </div> -->
-                </div>
-              </div>
-              <table class="tablemain">
-                <thead>
-                  <tr>
-                    <th style="width: 25%">
-                      Mês/Ano
-                    </th>
-                    <th style="width: 17.5%">
-                      Previsto Mensal
-                    </th>
-                    <th style="width: 17.5%">
-                      Realizado Mensal
-                    </th>
-                    <th style="width: 17.5%">
-                      Previsto Acumulado
-                    </th>
-                    <th style="width: 17.5%">
-                      Realizado Acumulado
-                    </th>
-                    <th style="width: 5%" />
-                  </tr>
-                </thead>
-
-                <GruposDeSerie
-                  :g="Valores[v.id]"
-                  variavel="true"
-                  :tem-variavel-acumulada="!!v.acumulativa"
-                />
-              </table>
-            </div>
-          </div>
+            <EvolucaoDeMetaIniciativaAtividade
+              :variavel="v"
+              :parent-link="parentLink"
+              :indicador="ind"
+            />
+          </EsperarEntrarNaTela>
         </template>
+
         <div
           v-else
           class="p1"
@@ -439,7 +280,7 @@ const { Variaveis, Valores } = storeToRefs(VariaveisStore);
       >
         <div class="tc">
           <SmaeLink
-            :to="`${parentlink}/indicadores/novo`"
+            :to="`${parentLink}/indicadores/novo`"
             class="btn mt1 mb1"
           >
             <span>Adicionar indicador</span>

--- a/frontend/src/views/metas/SingleEvolucao.vue
+++ b/frontend/src/views/metas/SingleEvolucao.vue
@@ -1,11 +1,8 @@
 <script setup>
-import { storeToRefs } from 'pinia';
-import { computed, ref } from 'vue';
-import { useRoute } from 'vue-router';
-import SmallModal from '@/components/SmallModal.vue';
-import { default as EvolucaoGraph } from '@/components/EvolucaoGraph.vue';
-import { default as GruposDeSerie } from '@/components/metas/GruposDeSerie.vue';
+import EvolucaoGraph from '@/components/EvolucaoGraph.vue';
+import GruposDeSerie from '@/components/metas/GruposDeSerie.vue';
 import MigalhasDeMetas from '@/components/metas/MigalhasDeMetas.vue';
+import SmallModal from '@/components/SmallModal.vue';
 import dateToField from '@/helpers/dateToField';
 import { useAuthStore } from '@/stores/auth.store';
 import { useIndicadoresStore } from '@/stores/indicadores.store';
@@ -14,6 +11,9 @@ import { useVariaveisStore } from '@/stores/variaveis.store';
 import AddEditRealizado from '@/views/metas/AddEditRealizado.vue';
 import AddEditValores from '@/views/metas/AddEditValores.vue';
 import AddEditVariavel from '@/views/metas/AddEditVariavel.vue';
+import { storeToRefs } from 'pinia';
+import { computed, ref } from 'vue';
+import { useRoute } from 'vue-router';
 
 const props = defineProps(['group']);
 
@@ -21,29 +21,33 @@ const authStore = useAuthStore();
 const { temPermissãoPara } = storeToRefs(authStore);
 
 const route = useRoute();
-const { meta_id } = route.params;
-const { iniciativa_id } = route.params;
-const { atividade_id } = route.params;
+const { meta_id: metaId } = route.params;
+const { iniciativa_id: iniciativaId } = route.params;
+const { atividade_id: atividadeId } = route.params;
 
 const MetasStore = useMetasStore();
 const { activePdm } = storeToRefs(MetasStore);
-const parent_id = atividade_id ?? iniciativa_id ?? meta_id ?? false;
-const parent_field = atividade_id ? 'atividade_id' : iniciativa_id ? 'iniciativa_id' : meta_id ? 'meta_id' : false;
-const parentLabel = ref(atividade_id ? '-' : iniciativa_id ? '-' : meta_id ? 'Meta' : false);
+const parentId = atividadeId ?? iniciativaId ?? metaId ?? false;
+// mantendo comportamento legado
+// eslint-disable-next-line no-nested-ternary
+const parentField = atividadeId ? 'atividade_id' : iniciativaId ? 'iniciativa_id' : metaId ? 'meta_id' : false;
+// mantendo comportamento legado
+// eslint-disable-next-line no-nested-ternary
+const parentLabel = ref(atividadeId ? '-' : iniciativaId ? '-' : metaId ? 'Meta' : false);
 
 const parentlink = (() => {
   let baseLink = window.location.origin;
 
-  if (meta_id) {
-    baseLink += `/metas/${meta_id}`;
+  if (metaId) {
+    baseLink += `/metas/${metaId}`;
   }
 
-  if (iniciativa_id) {
-    baseLink += `/iniciativas/${iniciativa_id}`;
+  if (iniciativaId) {
+    baseLink += `/iniciativas/${iniciativaId}`;
   }
 
-  if (atividade_id) {
-    baseLink += `/atividades/${atividade_id}`;
+  if (atividadeId) {
+    baseLink += `/atividades/${atividadeId}`;
   }
 
   return baseLink;
@@ -66,8 +70,8 @@ const dialogoAtivo = computed(() => {
 
 (async () => {
   await MetasStore.getPdM();
-  if (atividade_id) parentLabel.value = activePdm.value.rotulo_atividade;
-  else if (iniciativa_id) parentLabel.value = activePdm.value.rotulo_iniciativa;
+  if (atividadeId) parentLabel.value = activePdm.value.rotulo_atividade;
+  else if (iniciativaId) parentLabel.value = activePdm.value.rotulo_iniciativa;
 })();
 
 const IndicadoresStore = useIndicadoresStore();
@@ -77,7 +81,11 @@ const VariaveisStore = useVariaveisStore();
 const { Variaveis, Valores } = storeToRefs(VariaveisStore);
 
 (async () => {
-  if (!tempIndicadores.value.length || tempIndicadores.value[0][parent_field] != parent_id) await IndicadoresStore.filterIndicadores(parent_id, parent_field);
+  // mantendo comportamento legado
+  // eslint-disable-next-line eqeqeq
+  if (!tempIndicadores.value.length || tempIndicadores.value[0][parentField] != parentId) {
+    await IndicadoresStore.filterIndicadores(parentId, parentField);
+  }
   if (tempIndicadores.value[0]?.id) {
     IndicadoresStore.getValores(tempIndicadores.value[0]?.id);
     await VariaveisStore.getAll(tempIndicadores.value[0]?.id);
@@ -125,22 +133,36 @@ const { Variaveis, Valores } = storeToRefs(VariaveisStore);
                   color="#F2890D"
                   class="f0"
                   xmlns="http://www.w3.org/2000/svg"
-                > <path
-                  d="M24.9091 0.36377H3.09091C2.36759 0.36377 1.6739 0.651104 1.16244 1.16257C0.650975 1.67403 0.36364 2.36772 0.36364 3.09104V24.9092C0.36364 25.6325 0.650975 26.3262 1.16244 26.8377C1.6739 27.3492 2.36759 27.6365 3.09091 27.6365H24.9091C25.6324 27.6365 26.3261 27.3492 26.8376 26.8377C27.349 26.3262 27.6364 25.6325 27.6364 24.9092V3.09104C27.6364 2.36772 27.349 1.67403 26.8376 1.16257C26.3261 0.651104 25.6324 0.36377 24.9091 0.36377ZM24.9091 3.09104V8.54559H24.3636L22.1818 10.7274L16.5909 5.1365L11.1364 11.9547L7.18182 8.00012L3.90909 11.2729H3.09091V3.09104H24.9091ZM3.09091 24.9092V14.0001H5L7.18182 11.8183L11.4091 16.0456L16.8636 9.22741L22.1818 14.5456L25.5909 11.2729H24.9091V24.9092H3.09091Z"
-                  fill="currentColor"
-                /> <path
-                  d="M7.18182 19.4547H4.45455V23.5456H7.18182V19.4547Z"
-                  fill="currentColor"
-                /> <path
-                  d="M12.6364 18.091H9.90909V23.5456H12.6364V18.091Z"
-                  fill="currentColor"
-                /> <path
-                  d="M18.0909 15.3638H15.3636V23.5456H18.0909V15.3638Z"
-                  fill="currentColor"
-                /> <path
-                  d="M23.5455 18.091H20.8182V23.5456H23.5455V18.091Z"
-                  fill="currentColor"
-                /> </svg>
+                >
+                  <path
+                    d="M24.9091 0.36377H3.09091C2.36759 0.36377 1.6739 0.651104
+                    1.16244 1.16257C0.650975 1.67403 0.36364 2.36772 0.36364
+                    3.09104V24.9092C0.36364 25.6325 0.650975 26.3262 1.16244
+                    26.8377C1.6739 27.3492 2.36759 27.6365 3.09091
+                    27.6365H24.9091C25.6324 27.6365 26.3261 27.3492 26.8376
+                    26.8377C27.349 26.3262 27.6364 25.6325 27.6364
+                    24.9092V3.09104C27.6364 2.36772 27.349 1.67403 26.8376
+                    1.16257C26.3261 0.651104 25.6324 0.36377 24.9091
+                    0.36377ZM24.9091 3.09104V8.54559H24.3636L22.1818
+                    10.7274L16.5909 5.1365L11.1364 11.9547L7.18182 8.00012L3.90909
+                    11.2729H3.09091V3.09104H24.9091ZM3.09091
+                    24.9092V14.0001H5L7.18182 11.8183L11.4091 16.0456L16.8636
+                    9.22741L22.1818 14.5456L25.5909
+                    11.2729H24.9091V24.9092H3.09091Z"
+                    fill="currentColor"
+                  /> <path
+                    d="M7.18182 19.4547H4.45455V23.5456H7.18182V19.4547Z"
+                    fill="currentColor"
+                  /> <path
+                    d="M12.6364 18.091H9.90909V23.5456H12.6364V18.091Z"
+                    fill="currentColor"
+                  /> <path
+                    d="M18.0909 15.3638H15.3636V23.5456H18.0909V15.3638Z"
+                    fill="currentColor"
+                  /> <path
+                    d="M23.5455 18.091H20.8182V23.5456H23.5455V18.091Z"
+                    fill="currentColor"
+                  /> </svg>
                 <h2 class="mt1 mb1 ml1">
                   {{ ind.codigo }} - {{ ind.titulo }}
                 </h2>
@@ -183,7 +205,9 @@ const { Variaveis, Valores } = storeToRefs(VariaveisStore);
                     <svg
                       width="20"
                       height="20"
-                    ><use xlink:href="#i_i" /></svg><div>Indicador calculado pelo média móvel das variáveis</div>
+                    ><use xlink:href="#i_i" /></svg><div>
+                      Indicador calculado pelo média móvel das variáveis
+                    </div>
                   </div>
                 </div>
               </div>
@@ -236,7 +260,20 @@ const { Variaveis, Valores } = storeToRefs(VariaveisStore);
                     color="#8EC122"
                     xmlns="http://www.w3.org/2000/svg"
                   > <path
-                    d="M24.9091 0.36377H3.09091C2.36759 0.36377 1.6739 0.651104 1.16244 1.16257C0.650975 1.67403 0.36364 2.36772 0.36364 3.09104V24.9092C0.36364 25.6325 0.650975 26.3262 1.16244 26.8377C1.6739 27.3492 2.36759 27.6365 3.09091 27.6365H24.9091C25.6324 27.6365 26.3261 27.3492 26.8376 26.8377C27.349 26.3262 27.6364 25.6325 27.6364 24.9092V3.09104C27.6364 2.36772 27.349 1.67403 26.8376 1.16257C26.3261 0.651104 25.6324 0.36377 24.9091 0.36377ZM24.9091 3.09104V8.54559H24.3636L22.1818 10.7274L16.5909 5.1365L11.1364 11.9547L7.18182 8.00012L3.90909 11.2729H3.09091V3.09104H24.9091ZM3.09091 24.9092V14.0001H5L7.18182 11.8183L11.4091 16.0456L16.8636 9.22741L22.1818 14.5456L25.5909 11.2729H24.9091V24.9092H3.09091Z"
+                    d="M24.9091 0.36377H3.09091C2.36759 0.36377 1.6739 0.651104
+                    1.16244 1.16257C0.650975 1.67403 0.36364 2.36772 0.36364
+                    3.09104V24.9092C0.36364 25.6325 0.650975 26.3262 1.16244
+                    26.8377C1.6739 27.3492 2.36759 27.6365 3.09091
+                    27.6365H24.9091C25.6324 27.6365 26.3261 27.3492 26.8376
+                    26.8377C27.349 26.3262 27.6364 25.6325 27.6364
+                    24.9092V3.09104C27.6364 2.36772 27.349 1.67403 26.8376
+                    1.16257C26.3261 0.651104 25.6324 0.36377 24.9091
+                    0.36377ZM24.9091 3.09104V8.54559H24.3636L22.1818
+                    10.7274L16.5909 5.1365L11.1364 11.9547L7.18182 8.00012L3.90909
+                    11.2729H3.09091V3.09104H24.9091ZM3.09091
+                    24.9092V14.0001H5L7.18182 11.8183L11.4091 16.0456L16.8636
+                    9.22741L22.1818 14.5456L25.5909
+                    11.2729H24.9091V24.9092H3.09091Z"
                     fill="currentColor"
                   /> <path
                     d="M7.18182 19.4547H4.45455V23.5456H7.18182V19.4547Z"
@@ -328,11 +365,16 @@ const { Variaveis, Valores } = storeToRefs(VariaveisStore);
                       <svg
                         width="20"
                         height="20"
-                      ><use xlink:href="#i_i" /></svg><div>Indicador calculado pelo média móvel das variáveis</div>
+                      ><use xlink:href="#i_i" /></svg><div>
+                        Indicador calculado pelo média móvel das variáveis
+                      </div>
                     </div>
                   </div>
                   <!-- <div>
-                        <a class="addlink"><svg width="20" height="20"><use xlink:href="#i_+"></use></svg><span>Adicionar período</span></a>
+                        <a class="addlink"><svg width="20"
+                          height="20"><use xlink:href="#i_+"></use></svg><span>
+                          Adicionar período
+                        </span></a>
                     </div> -->
                 </div>
               </div>


### PR DESCRIPTION
@GustavoFSoares , eu tornei parte do que você fez reativa para que o `SingleEvolucao.vue` perceba a troca da rota, agora que elas estão aninhadas.

As páginas não só recarregavam por serem rotas irmãs num mesmo arquivo, como eram usadas como chave no elemento raiz. Em `App.vue`:

```vue
  <!-- vamos avançar até essa chave ser desnecessária para o sistema todo -->
  <router-view v-if="$route.meta.rotaPrescindeDeChave ?? gblHabilitarBeta" />
  <router-view
    v-else
    :key="$route.path"
  />
```

---

@Eduruiz , fiquei na solução mais simples do "carregamento preguiçoso" porque o Vue faz todas as mudanças de uma vez, então não consegui pegar o estado elemento no momento certo. Porém, ainda não desisti.

Se quiser renomear o componente novo, fique a vontade.