### PR TITLE
[fix] S20.GP005  - S20.GP007 

### DIFF
--- a/frontend/src/components/cardEnvelope/CardEnvelopeTitulo.vue
+++ b/frontend/src/components/cardEnvelope/CardEnvelopeTitulo.vue
@@ -22,7 +22,7 @@
     </h2>
     <p
       v-if="$slots?.subtitulo || subtitulo"
-      class="card-envelope-titulo__texto__subtitulo t12"
+      class="card-envelope-titulo__texto__subtitulo t14"
     >
       <slot name="subtitulo">
         {{ subtitulo }}

--- a/frontend/src/components/painelEstrategico/ResumoOrcamentario.vue
+++ b/frontend/src/components/painelEstrategico/ResumoOrcamentario.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { defineProps } from 'vue';
 import dinheiro from '@/helpers/dinheiro';
+import AnimatedNumber from '@/components/AnimatedNumber.vue';
 
 defineProps({
   planejadoTotal: {
@@ -24,25 +25,49 @@ defineProps({
       <dt class="mb0 t12 w700 uc">
         Custo planejado total:
       </dt>
-      <dd class="mb0 t36 w700">
-        R$ {{ dinheiro(Number(planejadoTotal)) }}
-      </dd>
+      <AnimatedNumber
+        :value="Number(planejadoTotal)"
+        as="dd"
+        :formatter="dinheiro"
+        slowness="2"
+        class="mb0 t36 w700"
+      >
+        <template #prefix>
+          R$
+        </template>
+      </AnimatedNumber>
     </div>
     <div class="pb1 flex column end">
       <dt class="mb0 t12 w700 uc">
         Valor empenhado total:
       </dt>
-      <dd class="mb0 t36 w700">
-        R$ {{ dinheiro(Number(empenhoTotal)) }}
-      </dd>
+      <AnimatedNumber
+        :value="Number(empenhoTotal)"
+        as="dd"
+        :formatter="dinheiro"
+        slowness="2"
+        class="mb0 t36 w700"
+      >
+        <template #prefix>
+          R$
+        </template>
+      </AnimatedNumber>
     </div>
     <div class="pb1 flex column end">
       <dt class="mb0 t12 w700 uc">
         Valor liquidado total:
       </dt>
-      <dd class="mb0 t36 w700 liquidado">
-        R$ {{ dinheiro(Number(liquidadoTotal)) }}
-      </dd>
+      <AnimatedNumber
+        :value="Number(liquidadoTotal)"
+        as="dd"
+        :formatter="dinheiro"
+        slowness="2"
+        class="mb0 t36 w700 liquidado"
+      >
+        <template #prefix>
+          R$
+        </template>
+      </AnimatedNumber>
     </div>
   </dl>
 </template>


### PR DESCRIPTION
Ajustes de estilos dos cards: 
- [S20.GP005 - Painel estratégico - aumentar fonte dos subtitulos](https://trello.com/c/nGIUF67E/1846-s20gp005-painel-estrat%C3%A9gico-aumentar-fonte-dos-subtitulos )
- [S20.GP007 - Painel estratégico](https://trello.com/c/17GUWelj/1848-s20gp007-painel-estrat%C3%A9gico-colocar-casas-decimais-no-resumo-or%C3%A7ament%C3%A1rio )