### PR TITLE
fix: ajusta os relatórios de orçamento pra ter loading pro download

### DIFF
--- a/frontend/src/components/relatorios/TabelaBasica.vue
+++ b/frontend/src/components/relatorios/TabelaBasica.vue
@@ -5,6 +5,7 @@ import { useAlertStore } from '@/stores/alert.store';
 import { useAuthStore } from '@/stores/auth.store';
 import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
 import { localizarData, localizarDataHorario } from '@/helpers/dateToDate';
+import LoadingComponent from '@/components/LoadingComponent.vue';
 
 const alertStore = useAlertStore();
 const relatoriosStore = useRelatoriosStore();
@@ -78,35 +79,50 @@ function excluirRelatório(id) {
             <template v-else>
               {{ Array.isArray(item.parametros[chave])
                 ? item.parametros[chave]
-                  .map((x) => props.etiquetasParaValoresDeParâmetros?.[chave]?.[x])
+                  .map((x) =>
+                    typeof x === 'boolean'
+                      ? (x ? 'Sim' : 'Não')
+                      : props.etiquetasParaValoresDeParâmetros?.[chave]?.[x] || x
+                  )
                   .join(', ')
-                : props.etiquetasParaValoresDeParâmetros?.[chave]?.[item.parametros[chave]]
-                  || item.parametros[chave] }}
+                : typeof item.parametros[chave] === 'boolean'
+                  ? (item.parametros[chave] ? 'Sim' : 'Não')
+                  : props.etiquetasParaValoresDeParâmetros?.[chave]?.[item.parametros[chave]]
+                    || item.parametros[chave] }}
             </template>
           </td>
 
           <td class="tr">
-            <button
-              v-if="temPermissãoPara(['Reports.remover.'])"
-              class="like-a__text addlink"
-              arial-label="excluir"
-              title="excluir"
-              @click="excluirRelatório(item.id)"
-            >
-              <svg
-                width="20"
-                height="20"
-              ><use xlink:href="#i_waste" /></svg>
-            </button>
-
-            <a
-              class="ml1"
-              :href="`${baseUrl}/download/${item.arquivo}`"
-              download
-              title="baixar"
-            ><img
-              src="../../assets/icons/baixar.svg"
-            ></a>
+            <div class="flex g05">
+              <button
+                v-if="temPermissãoPara(['Reports.remover.'])"
+                class="like-a__text addlink"
+                arial-label="excluir"
+                title="excluir"
+                @click="excluirRelatório(item.id)"
+              >
+                <svg
+                  width="20"
+                  height="20"
+                ><use xlink:href="#i_waste" /></svg>
+              </button>
+              <LoadingComponent
+                v-if="!item.arquivo"
+                title="Relatório em processamento"
+              >
+                <span class="sr-only">
+                  Relatório em processamento
+                </span>
+              </LoadingComponent>
+              <a
+                v-else
+                :href="`${baseUrl}/download/${item.arquivo}`"
+                download
+                title="baixar"
+              ><img
+                src="@/assets/icons/baixar.svg"
+              ></a>
+            </div>
           </td>
         </tr>
       </template>

--- a/frontend/src/components/relatorios/TabelaDeOrcamentarios.vue
+++ b/frontend/src/components/relatorios/TabelaDeOrcamentarios.vue
@@ -7,6 +7,7 @@ import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
 import dateToTitle from '@/helpers/dateToTitle';
 import { localizarDataHorario } from '@/helpers/dateToDate';
 import { relatorioOrcamentarioPlanoSetorial as schema } from '@/consts/formSchemas';
+import LoadingComponent from '@/components/LoadingComponent.vue';
 
 const alertStore = useAlertStore();
 const relatoriosStore = useRelatoriosStore();
@@ -61,34 +62,44 @@ function excluirRelatório(id) {
           </td>
 
           <td class="tr">
-            <button
-              v-if="temPermissãoPara(['Reports.remover.'])"
-              class="like-a__text addlink"
-              arial-label="excluir"
-              title="excluir"
-              @click="excluirRelatório(item.id)"
-            >
-              <svg
-                width="20"
-                height="20"
+            <div class="flex g05">
+              <button
+                v-if="temPermissãoPara(['Reports.remover.'])"
+                class="like-a__text addlink"
+                arial-label="excluir"
+                title="excluir"
+                @click="excluirRelatório(item.id)"
               >
-                <use xlink:href="#i_waste" />
-              </svg>
-            </button>
-
-            <a
-              class="ml1"
-              :href="`${baseUrl}/download/${item.arquivo}`"
-              download
-              title="baixar"
-            >
-              <svg
-                width="20"
-                height="20"
+                <svg
+                  width="20"
+                  height="20"
+                >
+                  <use xlink:href="#i_waste" />
+                </svg>
+              </button>
+              <LoadingComponent
+                v-if="!item.arquivo"
+                title="Relatório em processamento"
               >
-                <use xlink:href="#i_baixar" />
-              </svg>
-            </a>
+                <span class="sr-only">
+                  Relatório em processamento
+                </span>
+              </LoadingComponent>
+              <a
+                v-else
+                class="ml1"
+                :href="`${baseUrl}/download/${item.arquivo}`"
+                download
+                title="baixar"
+              >
+                <svg
+                  width="20"
+                  height="20"
+                >
+                  <use xlink:href="#i_baixar" />
+                </svg>
+              </a>
+            </div>
           </td>
         </tr>
       </template>

--- a/frontend/src/consts/formSchemas.js
+++ b/frontend/src/consts/formSchemas.js
@@ -2868,6 +2868,9 @@ export const relatórioDePrevisãoDeCustoPortfolio = object()
         .min(startYear, `\${label} não pode ser menor do que ${startYear}`)
         .max(endYear, `\${label} não pode ser maior do que ${endYear}`)
         .required(),
+      eh_publico: boolean()
+        .label('Relatório Público')
+        .required(),
     }),
     salvar_arquivo: boolean(),
   });
@@ -2886,6 +2889,9 @@ export const relatórioDeProjeto = object({
       .min(1, '${label} é obrigatório')
       .required()
       .transform((v) => (v === '' || Number.isNaN(v) ? null : v)),
+    eh_publico: boolean()
+      .label('Relatório Público')
+      .required(),
   }),
   salvar_arquivo: boolean(),
 });
@@ -2914,6 +2920,9 @@ export const relatórioDeStatus = object({
       .label('Projeto')
       .nullable()
       .transform((v) => (v === '' || Number.isNaN(v) ? null : v)),
+    eh_publico: boolean()
+      .label('Relatório Público')
+      .required(),
   }),
   salvar_arquivo: boolean(),
 });
@@ -2973,6 +2982,9 @@ export const relatórioDePortfolio = object({
         'Validado',
         null,
       ]),
+    eh_publico: boolean()
+      .label('Relatório Público')
+      .required(),
   }),
   salvar_arquivo: boolean(),
 });
@@ -3274,6 +3286,9 @@ export const relatórioOrçamentárioPortfolio = object({
         'Analitico',
         'Consolidado',
       ])
+      .required(),
+    eh_publico: boolean()
+      .label('Relatório Público')
       .required(),
   }),
 });

--- a/frontend/src/views/relatorios/NovoRelatorioDePortfolio.vue
+++ b/frontend/src/views/relatorios/NovoRelatorioDePortfolio.vue
@@ -33,26 +33,18 @@ const initialValues = {
     orgao_responsavel_id: null,
     portfolio_id: null,
   },
-  salvar_arquivo: false,
 };
 
 async function onSubmit(values) {
   const carga = values;
 
   try {
-    if (!carga.salvar_arquivo) {
-      carga.salvar_arquivo = false;
-    }
-
-    const msg = 'Dados salvos com sucesso!';
+    const msg = 'Relatório em processamento, acompanhe na tela de listagem';
     const r = await relatoriosStore.insert(carga);
 
     if (r === true) {
       alertStore.success(msg);
-
-      if (carga.salvar_arquivo && route.meta?.rotaDeEscape) {
-        router.push({ name: route.meta.rotaDeEscape });
-      }
+      router.push({ name: route.meta.rotaDeEscape });
     }
   } catch (error) {
     alertStore.error(error);
@@ -79,7 +71,7 @@ iniciar();
   </header>
 
   <Form
-    v-slot="{ errors, isSubmitting, values }"
+    v-slot="{ errors, isSubmitting }"
     :validation-schema="schema"
     :initial-values="initialValues"
     @submit="onSubmit"
@@ -183,25 +175,39 @@ iniciar();
           {{ errors['parametros.status'] }}
         </div>
       </div>
-    </div>
 
-    <div class="mb2">
-      <div class="pl2">
-        <label class="block">
-          <Field
-            name="salvar_arquivo"
-            type="checkbox"
-            :value="true"
-            class="inputcheckbox"
-          />
-          <span :class="{ 'error': errors.salvar_arquivo }">Salvar relatório no sistema</span>
-        </label>
-      </div>
-      <div
-        v-if="errors.salvar_arquivo"
-        class="error-msg"
-      >
-        {{ errors.salvar_arquivo }}
+      <div class="f1">
+        <LabelFromYup
+          name="eh_publico"
+          :schema="schema.fields.parametros"
+        />
+        <Field
+          name="parametros.eh_publico"
+          as="select"
+          class="inputtext light
+            mb1"
+          :class="{
+            error: errors['parametros.eh_publico'],
+            loading: portfolioStore.chamadasPendentes.lista
+          }"
+          :disabled="portfolioStore.chamadasPendentes.lista"
+        >
+          <option>
+            Selecionar
+          </option>
+          <option :value="true">
+            Sim
+          </option>
+          <option :value="false">
+            Não
+          </option>
+        </Field>
+        <div
+          v-if="errors['parametros.projeto_id']"
+          class="error-msg"
+        >
+          {{ errors['parametros.projeto_id'] }}
+        </div>
       </div>
     </div>
 
@@ -216,7 +222,7 @@ iniciar();
           ? `Erros de preenchimento: ${Object.keys(errors)?.length}`
           : null"
       >
-        {{ values.salvar_arquivo ? "baixar e salvar" : "apenas baixar" }}
+        Criar relatório
       </button>
       <hr class="ml2 f1">
     </div>

--- a/frontend/src/views/relatorios/NovoRelatorioDePrevisaoDeCustoPortfolio.vue
+++ b/frontend/src/views/relatorios/NovoRelatorioDePrevisaoDeCustoPortfolio.vue
@@ -30,27 +30,22 @@ const initialValues = computed(() => ({
     portfolio_id: 0,
     projeto_id: null,
   },
-  salvar_arquivo: false,
 }));
 
 async function onSubmit(values) {
   const carga = values;
   try {
-    if (!carga.salvar_arquivo) {
-      carga.salvar_arquivo = false;
-    }
-
     if (carga.parametros.projeto_id === null) {
       delete carga.parametros.projeto_id;
     }
 
     const r = await relatoriosStore.insert(carga);
-    const msg = 'Dados salvos com sucesso!';
+    const msg = 'Relatório em processamento, acompanhe na tela de listagem';
 
     if (r === true) {
       alertStore.success(msg);
 
-      if (carga.salvar_arquivo && route.meta?.rotaDeEscape) {
+      if (route.meta?.rotaDeEscape) {
         await router.push({ name: route.meta.rotaDeEscape });
       }
     }
@@ -177,22 +172,39 @@ iniciar();
           {{ errors['parametros.ano'] }}
         </div>
       </div>
-    </div>
 
-    <div class="mb2">
-      <div class="pl2">
-        <label class="block">
-          <Field
-            name="salvar_arquivo"
-            type="checkbox"
-            :value="true"
-            class="inputcheckbox"
-          />
-          <span :class="{ 'error': errors.salvar_arquivo }">Salvar relatório no sistema</span>
-        </label>
-      </div>
-      <div class="error-msg">
-        {{ errors.salvar_arquivo }}
+      <div class="f1">
+        <LabelFromYup
+          name="eh_publico"
+          :schema="schema.fields.parametros"
+        />
+        <Field
+          name="parametros.eh_publico"
+          as="select"
+          class="inputtext light
+            mb1"
+          :class="{
+            error: errors['parametros.eh_publico'],
+            loading: projetosStore.chamadasPendentes.lista
+          }"
+          :disabled="projetosStore.chamadasPendentes.lista"
+        >
+          <option>
+            Selecionar
+          </option>
+          <option :value="true">
+            Sim
+          </option>
+          <option :value="false">
+            Não
+          </option>
+        </Field>
+        <div
+          v-if="errors['parametros.eh_publico']"
+          class="error-msg"
+        >
+          {{ errors['parametros.eh_publico'] }}
+        </div>
       </div>
     </div>
 
@@ -205,7 +217,7 @@ iniciar();
         class="btn big"
         :disabled="isSubmitting || Object.keys(errors)?.length"
       >
-        {{ values.salvar_arquivo ? "baixar e salvar" : "apenas baixar" }}
+        Criar relatório
       </button>
       <hr class="ml2 f1">
     </div>

--- a/frontend/src/views/relatorios/NovoRelatorioDeProjeto.vue
+++ b/frontend/src/views/relatorios/NovoRelatorioDeProjeto.vue
@@ -23,26 +23,19 @@ const initialValues = {
   parametros: {
     projeto_id: null,
   },
-  salvar_arquivo: false,
 };
 
 async function onSubmit(values) {
   const carga = values;
 
   try {
-    if (!carga.salvar_arquivo) {
-      carga.salvar_arquivo = false;
-    }
-
-    const msg = 'Dados salvos com sucesso!';
+    const msg = 'Relatório em processamento, acompanhe na tela de listagem';
     const r = await relatóriosStore.insert(carga);
 
     if (r === true) {
       alertStore.success(msg);
 
-      if (carga.salvar_arquivo && route.meta?.rotaDeEscape) {
-        router.push({ name: route.meta.rotaDeEscape });
-      }
+      router.push({ name: route.meta.rotaDeEscape });
     }
   } catch (error) {
     alertStore.error(error);
@@ -143,22 +136,38 @@ projetosStore.buscarTudo();
           {{ errors['parametros.projeto_id'] }}
         </div>
       </div>
-    </div>
-
-    <div class="mb2">
-      <div class="pl2">
-        <label class="block">
-          <Field
-            name="salvar_arquivo"
-            type="checkbox"
-            :value="true"
-            class="inputcheckbox"
-          />
-          <span :class="{ 'error': errors.salvar_arquivo }">Salvar relatório no sistema</span>
-        </label>
-      </div>
-      <div class="error-msg">
-        {{ errors.salvar_arquivo }}
+      <div class="f1">
+        <LabelFromYup
+          name="eh_publico"
+          :schema="schema.fields.parametros"
+        />
+        <Field
+          name="parametros.eh_publico"
+          as="select"
+          class="inputtext light
+            mb1"
+          :class="{
+            error: errors['parametros.eh_publico'],
+            loading: projetosStore.chamadasPendentes.lista
+          }"
+          :disabled="projetosStore.chamadasPendentes.lista"
+        >
+          <option>
+            Selecionar
+          </option>
+          <option :value="true">
+            Sim
+          </option>
+          <option :value="false">
+            Não
+          </option>
+        </Field>
+        <div
+          v-if="errors['parametros.eh_publico']"
+          class="error-msg"
+        >
+          {{ errors['parametros.eh_publico'] }}
+        </div>
       </div>
     </div>
 
@@ -173,7 +182,7 @@ projetosStore.buscarTudo();
           ? `Erros de preenchimento: ${Object.keys(errors)?.length}`
           : null"
       >
-        {{ values.salvar_arquivo ? "baixar e salvar" : "apenas baixar" }}
+        Criar relatório
       </button>
       <hr class="ml2 f1">
     </div>

--- a/frontend/src/views/relatorios/NovoRelatorioDeStatus.vue
+++ b/frontend/src/views/relatorios/NovoRelatorioDeStatus.vue
@@ -26,25 +26,18 @@ const initialValues = {
     periodo_inicio: null,
     periodo_fim: null,
   },
-  salvar_arquivo: false,
 };
 
 async function onSubmit(values) {
   const carga = values;
 
   try {
-    if (!carga.salvar_arquivo) {
-      carga.salvar_arquivo = false;
-    }
-
-    const msg = 'Dados salvos com sucesso!';
+    const msg = 'Relatório em processamento, acompanhe na tela de listagem';
     const r = await relatoriosStore.insert(carga);
 
     if (r === true) {
       alertStore.success(msg);
-      if (carga.salvar_arquivo && route.meta?.rotaDeEscape) {
-        router.push({ name: route.meta.rotaDeEscape });
-      }
+      router.push({ name: route.meta.rotaDeEscape });
     }
   } catch (error) {
     alertStore.error(error);
@@ -146,6 +139,41 @@ projetosStore.buscarTudo();
           {{ errors['parametros.projeto_id'] }}
         </div>
       </div>
+
+      <div class="f1">
+        <LabelFromYup
+          name="eh_publico"
+          :schema="schema.fields.parametros"
+        />
+        <Field
+          name="parametros.eh_publico"
+          as="select"
+          class="inputtext light
+            mb1"
+          :class="{
+            error: errors['parametros.eh_publico'],
+            loading: projetosStore.chamadasPendentes.lista
+          }"
+          :disabled="projetosStore.chamadasPendentes.lista"
+        >
+          <option>
+            Selecionar
+          </option>
+          <option :value="true">
+            Sim
+          </option>
+          <option :value="false">
+            Não
+          </option>
+        </Field>
+        <div
+          v-if="errors['parametros.eh_publico']"
+          class="error-msg"
+        >
+          {{ errors['parametros.eh_publico'] }}
+        </div>
+      </div>
+
     </div>
 
     <div class="flex g2 mb2">
@@ -193,26 +221,6 @@ projetosStore.buscarTudo();
       </div>
     </div>
 
-    <div class="mb2">
-      <div class="pl2">
-        <label class="block">
-          <Field
-            name="salvar_arquivo"
-            type="checkbox"
-            :value="true"
-            class="inputcheckbox"
-          />
-          <span :class="{ 'error': errors.salvar_arquivo }">Salvar relatório no sistema</span>
-        </label>
-      </div>
-      <div
-        v-if="errors['salvar_arquivo']"
-        class="error-msg"
-      >
-        {{ errors['salvar_arquivo'] }}
-      </div>
-    </div>
-
     <FormErrorsList :errors="errors" />
 
     <div class="flex spacebetween center mb2">
@@ -224,7 +232,7 @@ projetosStore.buscarTudo();
           ? `Erros de preenchimento: ${Object.keys(errors)?.length}`
           : null"
       >
-        {{ values.salvar_arquivo ? "baixar e salvar" : "apenas baixar" }}
+        Criar relatório
       </button>
       <hr class="ml2 f1">
     </div>

--- a/frontend/src/views/relatorios/RelatoriosDeAtividadesPendentes.vue
+++ b/frontend/src/views/relatorios/RelatoriosDeAtividadesPendentes.vue
@@ -6,6 +6,8 @@ import BotãoParaCarregarMais from '@/components/relatorios/BotaoParaCarregarMai
 import { relatórioAtividadesPendentes as schema } from '@/consts/formSchemas';
 import { useAuthStore } from '@/stores/auth.store';
 import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
+// Mantendo comportamento legado
+// eslint-disable-next-line import/no-cycle
 import {
   prepararEtiquetas,
   prepararEsferaDeTransferência,

--- a/frontend/src/views/relatorios/RelatoriosDePortfolioObras.vue
+++ b/frontend/src/views/relatorios/RelatoriosDePortfolioObras.vue
@@ -6,6 +6,8 @@ import { useAuthStore } from '@/stores/auth.store';
 import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
 import { storeToRefs } from 'pinia';
 import { ref } from 'vue';
+// Mantendo comportamento legado
+// eslint-disable-next-line import/no-cycle
 import { prepararEtiquetas, prepararPortfoliosObras, prepararÓrgãos } from './helpers/preparadorDeColunaParametros';
 
 const relatóriosStore = useRelatoriosStore();

--- a/frontend/src/views/relatorios/RelatoriosDePrevisaoDeCustoPortfolio.vue
+++ b/frontend/src/views/relatorios/RelatoriosDePrevisaoDeCustoPortfolio.vue
@@ -4,8 +4,15 @@ import TabelaBásica from '@/components/relatorios/TabelaBasica.vue';
 import { useAuthStore } from '@/stores/auth.store';
 import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
 import { storeToRefs } from 'pinia';
-import { ref } from 'vue';
+import {
+  ref,
+  onUnmounted,
+  computed,
+  watch,
+} from 'vue';
 import { relatórioDePrevisãoDeCustoPortfolio as schema } from '@/consts/formSchemas';
+// Mantendo comportamento legado
+// eslint-disable-next-line import/no-cycle
 import { prepararEtiquetas, prepararPortfolios } from './helpers/preparadorDeColunaParametros';
 
 const relatóriosStore = useRelatoriosStore();
@@ -18,15 +25,39 @@ const etiquetasParaValoresDeParâmetros = ref({
 });
 
 const etiquetasParaParâmetros = prepararEtiquetas(schema);
+let intervaloDeAtualizacao = null;
+const temAlgumRelatorioEmProcessamento = computed(() => relatóriosStore
+  .lista.some((relatorio) => !relatorio.arquivo));
+
+async function carregarRelatorios() {
+  await relatóriosStore.getAll({ fonte });
+}
 
 async function iniciar() {
   relatóriosStore.$reset();
-  relatóriosStore.getAll({ fonte });
+  await carregarRelatorios();
 
   etiquetasParaValoresDeParâmetros.value.portfolio_id = await prepararPortfolios();
 }
 
+watch(temAlgumRelatorioEmProcessamento, (novoValor) => {
+  if (novoValor) {
+    if (!intervaloDeAtualizacao) {
+      intervaloDeAtualizacao = setInterval(carregarRelatorios, 5000);
+    }
+  } else {
+    clearInterval(intervaloDeAtualizacao);
+    intervaloDeAtualizacao = null;
+  }
+});
+
 iniciar();
+
+onUnmounted(() => {
+  if (intervaloDeAtualizacao) {
+    clearInterval(intervaloDeAtualizacao);
+  }
+});
 </script>
 <template>
   <div class="flex spacebetween center mb2">

--- a/frontend/src/views/relatorios/RelatoriosDePrevisaoDeCustoPortfolioObras.vue
+++ b/frontend/src/views/relatorios/RelatoriosDePrevisaoDeCustoPortfolioObras.vue
@@ -6,6 +6,8 @@ import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
 import { storeToRefs } from 'pinia';
 import { ref } from 'vue';
 import { relatórioDePrevisãoDeCustoPortfolioObras as schema } from '@/consts/formSchemas';
+// Mantendo comportamento legado
+// eslint-disable-next-line import/no-cycle
 import { prepararEtiquetas, prepararPortfoliosObras } from './helpers/preparadorDeColunaParametros';
 
 const relatóriosStore = useRelatoriosStore();
@@ -14,7 +16,7 @@ const { temPermissãoPara } = storeToRefs(useAuthStore());
 const fonte = 'ObrasPrevisaoCusto';
 
 const etiquetasParaValoresDeParâmetros = ref({
-  portfolio_id: {}, 
+  portfolio_id: {},
 });
 
 const etiquetasParaParâmetros = prepararEtiquetas(schema);

--- a/frontend/src/views/relatorios/RelatoriosDeProjeto.vue
+++ b/frontend/src/views/relatorios/RelatoriosDeProjeto.vue
@@ -5,7 +5,14 @@ import TabelaBásica from '@/components/relatorios/TabelaBasica.vue';
 import { useAuthStore } from '@/stores/auth.store';
 import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
 import { storeToRefs } from 'pinia';
-import { ref } from 'vue';
+import {
+  ref,
+  onUnmounted,
+  computed,
+  watch,
+} from 'vue';
+// Mantendo comportamento legado
+// eslint-disable-next-line import/no-cycle
 import { prepararEtiquetas, prepararProjetos, prepararPortfolios } from './helpers/preparadorDeColunaParametros';
 
 const relatóriosStore = useRelatoriosStore();
@@ -18,15 +25,39 @@ const etiquetasParaValoresDeParâmetros = ref({
 });
 
 const etiquetasParaParâmetros = prepararEtiquetas(schema);
+let intervaloDeAtualizacao = null;
+const temAlgumRelatorioEmProcessamento = computed(() => relatóriosStore
+  .lista.some((relatorio) => !relatorio.arquivo));
+
+async function carregarRelatorios() {
+  await relatóriosStore.getAll({ fonte });
+}
 
 async function iniciar() {
   relatóriosStore.$reset();
-  relatóriosStore.getAll({ fonte });
+  await carregarRelatorios();
   etiquetasParaValoresDeParâmetros.value.portfolio_id = await prepararPortfolios();
   etiquetasParaValoresDeParâmetros.value.projeto_id = await prepararProjetos();
 }
 
+watch(temAlgumRelatorioEmProcessamento, (novoValor) => {
+  if (novoValor) {
+    if (!intervaloDeAtualizacao) {
+      intervaloDeAtualizacao = setInterval(carregarRelatorios, 5000);
+    }
+  } else {
+    clearInterval(intervaloDeAtualizacao);
+    intervaloDeAtualizacao = null;
+  }
+});
+
 iniciar();
+
+onUnmounted(() => {
+  if (intervaloDeAtualizacao) {
+    clearInterval(intervaloDeAtualizacao);
+  }
+});
 </script>
 <template>
   <div class="flex spacebetween center mb2">

--- a/frontend/src/views/relatorios/RelatoriosDeStatus.vue
+++ b/frontend/src/views/relatorios/RelatoriosDeStatus.vue
@@ -4,8 +4,15 @@ import TabelaBásica from '@/components/relatorios/TabelaBasica.vue';
 import { useAuthStore } from '@/stores/auth.store';
 import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
 import { storeToRefs } from 'pinia';
-import { ref } from 'vue';
+import {
+  ref,
+  onUnmounted,
+  computed,
+  watch,
+} from 'vue';
 import { relatórioDeStatus as schema } from '@/consts/formSchemas';
+// Mantendo comportamento legado
+// eslint-disable-next-line import/no-cycle
 import { prepararEtiquetas, prepararPortfolios } from './helpers/preparadorDeColunaParametros';
 
 const relatóriosStore = useRelatoriosStore();
@@ -16,14 +23,38 @@ const etiquetasParaValoresDeParâmetros = ref({
 });
 
 const etiquetasParaParâmetros = prepararEtiquetas(schema);
+let intervaloDeAtualizacao = null;
+const temAlgumRelatorioEmProcessamento = computed(() => relatóriosStore
+  .lista.some((relatorio) => !relatorio.arquivo));
+
+async function carregarRelatorios() {
+  await relatóriosStore.getAll({ fonte });
+}
 
 async function iniciar() {
   relatóriosStore.$reset();
-  relatóriosStore.getAll({ fonte });
+  await carregarRelatorios();
   etiquetasParaValoresDeParâmetros.value.portfolio_id = await prepararPortfolios();
 }
 
+watch(temAlgumRelatorioEmProcessamento, (novoValor) => {
+  if (novoValor) {
+    if (!intervaloDeAtualizacao) {
+      intervaloDeAtualizacao = setInterval(carregarRelatorios, 5000);
+    }
+  } else {
+    clearInterval(intervaloDeAtualizacao);
+    intervaloDeAtualizacao = null;
+  }
+});
+
 iniciar();
+
+onUnmounted(() => {
+  if (intervaloDeAtualizacao) {
+    clearInterval(intervaloDeAtualizacao);
+  }
+});
 </script>
 <template>
   <div class="flex spacebetween center mb2">

--- a/frontend/src/views/relatorios/RelatoriosDeTransferenciasVoluntarias.vue
+++ b/frontend/src/views/relatorios/RelatoriosDeTransferenciasVoluntarias.vue
@@ -6,6 +6,8 @@ import { useAuthStore } from '@/stores/auth.store';
 import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
 import { storeToRefs } from 'pinia';
 import { ref } from 'vue';
+// Mantendo comportamento legado
+// eslint-disable-next-line import/no-cycle
 import {
   prepararEsferaDeTransferência,
   prepararEtiquetas,
@@ -38,7 +40,6 @@ async function iniciar() {
   etiquetasParaValoresDeParâmetros.value.orgao_gestor_id = await prepararÓrgãos();
   etiquetasParaValoresDeParâmetros.value.partido_id = await prepararPartidos();
   etiquetasParaValoresDeParâmetros.value.parlamentar_id = await prepararParlamentares();
-
 }
 
 iniciar();

--- a/frontend/src/views/relatorios/helpers/preparadorDeColunaParametros.js
+++ b/frontend/src/views/relatorios/helpers/preparadorDeColunaParametros.js
@@ -33,12 +33,12 @@ export const prepararInterfaceDeTransferência = () => Object.values(interfacesD
 export const prepararCargos = () => Object.values(cargosDeParlamentar)
   .reduce((acc, cur) => ({ ...acc, [cur.valor]: cur.nome }), {});
 
-/*ÓrgãosStore.getAll()
+/* ÓrgãosStore.getAll()
   .then(() => ÓrgãosStore.órgãosComoLista
     .reduce((acc, cur) => ({ ...acc, [cur.id]: cur.sigla }), {}))
   .catch((error) => {
     throw new Error(error);
-  });*/
+  }); */
 
 export const prepararPdm = () => PdMStore.getAll()
   .then(() => (Array.isArray(PdMStore.PdM)
@@ -113,51 +113,47 @@ export const prepararTipoTransferencia = async () => {
   }
 };
 
-/* 
+/*
 export const prepararParlamentares = () => parlamentaresStore.buscarTudo()
   .then(() => parlamentaresStore.parlamentaresComoLista
     .reduce((acc, cur) => ({ ...acc, [cur.id]: cur.nome }), {}))
   .catch((error) => {
     throw new Error(error);
-  });*/
+  }); */
 
-  // Busca os parlamentares e substitui o código pelo nome de urna
-  export const prepararParlamentares = async () => {
-    try {
-      if (!parlamentaresStore.lista.length) {
-        await parlamentaresStore.buscarTudo();
-      }
-      return parlamentaresStore.lista.reduce((acc, cur) => ({
-        ...acc,
-        [cur.id]: cur.nome_popular,
-      }), {});
-    } catch (error) {
-      throw new Error(error);
+// Busca os parlamentares e substitui o código pelo nome de urna
+export const prepararParlamentares = async () => {
+  try {
+    if (!parlamentaresStore.lista.length) {
+      await parlamentaresStore.buscarTudo();
     }
-  };
+    return parlamentaresStore.lista.reduce((acc, cur) => ({
+      ...acc,
+      [cur.id]: cur.nome_popular,
+    }), {});
+  } catch (error) {
+    throw new Error(error);
+  }
+};
 
-  // Busca os órgãos e substitui o código pela sigla
-  export const prepararÓrgãos = async () => {
-    try {
-      if (!ÓrgãosStore.órgãosComoLista.length) {
-        await ÓrgãosStore.getAll();
-      }
-      return ÓrgãosStore.órgãosComoLista.reduce((acc, cur) => ({
-        ...acc,
-        [cur.id]: cur.sigla,
-      }), {});
-    } catch (error) {
-      throw new Error(error);
+// Busca os órgãos e substitui o código pela sigla
+export const prepararÓrgãos = async () => {
+  try {
+    if (!ÓrgãosStore.órgãosComoLista.length) {
+      await ÓrgãosStore.getAll();
     }
-  };
+    return ÓrgãosStore.órgãosComoLista.reduce((acc, cur) => ({
+      ...acc,
+      [cur.id]: cur.sigla,
+    }), {});
+  } catch (error) {
+    throw new Error(error);
+  }
+};
 
-
-
-
-
-/*export const prepararÓrgãos = () => ÓrgãosStore.getAll()
+/* export const prepararÓrgãos = () => ÓrgãosStore.getAll()
   .then(() => ÓrgãosStore.órgãosComoLista
     .reduce((acc, cur) => ({ ...acc, [cur.id]: cur.sigla }), {}))
   .catch((error) => {
     throw new Error(error);
-  });*/
+  }); */


### PR DESCRIPTION
Além de adicionar o loading pro backend processar o arquivo renomeia em vários textos dos itens de relatório pra fazer sentido com a nova lógica de sempre salvar os portfólios e setar se ele é ou não público