### PR TITLE
feat: add novo campo de meta e reflete ele nos gráficos

### DIFF
--- a/frontend/src/components/metas/SimpleIndicador.vue
+++ b/frontend/src/components/metas/SimpleIndicador.vue
@@ -124,6 +124,7 @@ iniciar();
           />
           <GraficoLinhasEvolucao
             v-else
+            :indicador="ind"
             :valores="ValoresInd[ind.id]"
           />
           <div class="tc">

--- a/frontend/src/consts/formSchemas.js
+++ b/frontend/src/consts/formSchemas.js
@@ -911,6 +911,10 @@ export const indicador = object()
       .label('Valor base do indicador')
       .transform((v) => (v === '' || Number.isNaN(v) ? null : v))
       .nullable(),
+    meta_valor_nominal: number()
+      .label('Valor alvo')
+      .transform((v) => (v === '' || Number.isNaN(v) ? null : v))
+      .nullable(),
     casas_decimais: number()
       .min(0)
       .max(35)

--- a/frontend/src/views/metas/AddEditIndicador.vue
+++ b/frontend/src/views/metas/AddEditIndicador.vue
@@ -191,6 +191,12 @@ async function onSubmit(values) {
       ? null
       : String(values.acumulado_valor_base);
 
+    values.meta_valor_nominal = values.meta_valor_nominal === ''
+      || values.meta_valor_nominal === null
+      || Number.isNaN(Number(values.meta_valor_nominal))
+      ? null
+      : String(values.meta_valor_nominal);
+
     values.casas_decimais = values.casas_decimais ? Number(values.casas_decimais) : null;
 
     if (!values.acumulado_usa_formula) {
@@ -776,6 +782,20 @@ watch(() => props.group, () => {
           <div class="error-msg">
             {{ errors.acumulado_valor_base }}
           </div>
+        </div>
+        <LabelFromYup
+          name="meta_valor_nominal"
+          :schema="schema"
+        />
+        <Field
+          name="meta_valor_nominal"
+          type="number"
+          :value="values.meta_valor_nominal"
+          class="inputtext light mb1"
+          :class="{ 'error': errors.meta_valor_nominal }"
+        />
+        <div class="error-msg">
+          {{ errors.meta_valor_nominal }}
         </div>
       </div>
       <div v-else-if="Variaveis[indicadorId]?.loading">


### PR DESCRIPTION
Criado novo campo de meta pra atividade e iniciativa que aparece no gráfico apenas quando preenchido, agora removemos a meta do gráfico e do big number quando não temos esse valor