### PR TITLE
S99.G003 Criar endpoint para sincronização dos cadastros básicos

### DIFF
--- a/backend/src/sync-cadastro-basico/dto/sync-cadastro-basico.dto.ts
+++ b/backend/src/sync-cadastro-basico/dto/sync-cadastro-basico.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { OrgaoDto } from 'src/orgao/entities/orgao.entity';
+import { UnidadeMedida } from 'src/unidade-medida/entities/unidade-medida.entity';
+import { FonteVariavelDto } from 'src/fonte-variavel/dto/fonte-variavel.dto';
+import { AssuntoVariavelDto } from 'src/assunto-variavel/dto/assunto-variavel.dto';
+import { ListVariavelCategoricaDto } from 'src/variavel-categorica/dto/variavel-categorica.dto';
+import { ObjetivoEstrategicoDto } from 'src/tema/entities/objetivo-estrategico.entity';
+import { MacroTemaDto } from 'src/macro-tema/entities/macro-tema.entity';
+import { SubTemaDto } from 'src/subtema/entities/subtema.entity';
+import { OdsDto } from 'src/ods/entities/ods.entity';
+import { TagDto } from 'src/tag/entities/tag.entity';
+import { ProjetoTagDto } from 'src/pp/projeto-tag/entities/tag.entity';
+// import { ProjetoTagMDO }
+import { ListTipoAditivoDto } from 'src/tipo-aditivo/dto/tipo-aditivo.dto';
+import { TipoIntervencao } from 'src/pp/tipo-intervencao/entities/tipo-intervencao.entity';
+import { Regiao } from 'src/regiao/entities/regiao.entity';
+
+type SyncCadastroBasicoTipo =
+    | OrgaoDto
+    | UnidadeMedida
+    | FonteVariavelDto
+    | AssuntoVariavelDto
+    | ListVariavelCategoricaDto
+    | ObjetivoEstrategicoDto
+    | MacroTemaDto
+    | SubTemaDto
+    | OdsDto
+    | TagDto
+    | ProjetoTagDto
+    | ListTipoAditivoDto
+    | TipoIntervencao
+    | Regiao;
+
+export class SyncCadastroBasicoDto {
+    @ApiProperty({ description: 'Tipo do cadastro básico', example: 'orgao' })
+    tipo: string;
+
+    @ApiProperty({ description: 'Versão do schema', example: '2024.0.1' })
+    versao: string;
+
+    @ApiProperty({ description: 'Lista de registros do tipo informado' })
+    linhas: SyncCadastroBasicoTipo[];
+}
+
+export class SyncResponseDto {
+    @ApiProperty({ description: 'Dados sincronizados' })
+    dados: SyncCadastroBasicoDto[];
+
+    @ApiProperty({
+        description: 'Se true, indica que o schema foi alterado e o frontend precisa baixar tudo novamente',
+        example: false,
+    })
+    schema_desatualizado: boolean;
+
+    @ApiProperty({ description: 'IDs de registros que foram removidos' })
+    removidos: { tipo: string; ids: number[] }[];
+}

--- a/backend/src/sync-cadastro-basico/sync-cadastro-basico.controller.ts
+++ b/backend/src/sync-cadastro-basico/sync-cadastro-basico.controller.ts
@@ -1,0 +1,8 @@
+import { Controller } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('Sincronização de Cadastro Básico')
+@Controller('sync-cadastro-basico')
+export class SyncCadastroBasicoController {
+    constructor(private readonly syncCadastroBasicoService: SyncCadastroBasicoController) {}
+}

--- a/backend/src/sync-cadastro-basico/sync-cadastro-basico.module.ts
+++ b/backend/src/sync-cadastro-basico/sync-cadastro-basico.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { SyncCadastroBasicoController } from './sync-cadastro-basico.controller';
+import { SyncCadastroBasicoService } from './sync-cadastro-basico.service';
+
+@Module({
+    imports: [PrismaModule],
+    controllers: [SyncCadastroBasicoController],
+    providers: [SyncCadastroBasicoService],
+})
+export class SyncCadastroBasicoModule {}

--- a/backend/src/sync-cadastro-basico/sync-cadastro-basico.service.ts
+++ b/backend/src/sync-cadastro-basico/sync-cadastro-basico.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+//import { SyncResponseDto, SyncCadastroBasicoDto } from './dto/sync-cadastro-basico.dto';
+
+@Injectable()
+export class SyncCadastroBasicoService {
+    constructor(private readonly prisma: PrismaService) {}
+}


### PR DESCRIPTION
- Criação de um endpoint com objetivo de permitir que o frontend mantenha uma cópia local dos cadastros básicos (orgão, região, etc) para funcionar offline e reduzir o número de requisições ao servidor.