### PR TITLE
fix: filtragem de metas pendentes não limpa

### DIFF
--- a/frontend/src/components/planoSetorialProgramaMetas.componentes/QuadroDeAtividades/CicloVigenteFiltro.vue
+++ b/frontend/src/components/planoSetorialProgramaMetas.componentes/QuadroDeAtividades/CicloVigenteFiltro.vue
@@ -8,12 +8,15 @@ const router = useRouter();
 const selecionado = ref(false);
 
 function handleFiltrar() {
-  const query = {
-    ...route.query,
-    apenas_pendentes: selecionado.value.toString(),
-  };
+  const novaQuery = structuredClone(route.query);
 
-  router.replace({ query });
+  if (selecionado.value) {
+    novaQuery.apenas_pendentes = 'true';
+  } else if (novaQuery.apenas_pendentes !== undefined) {
+    delete novaQuery.apenas_pendentes;
+  }
+
+  router.replace({ query: novaQuery });
 }
 
 watch(selecionado, () => handleFiltrar());


### PR DESCRIPTION
Acho que isso deveria ser resolvido no back., @reginaglaser . Pelo nome do parâmetro, `false` não deveria ser diferente de `null`.