### PR TITLE
feat: tela de edição em lote com revisão, campo dinâmico e integração com backend

### DIFF
--- a/frontend/src/components/alteracaoEmLotes.componentes/CampoDinamico.vue
+++ b/frontend/src/components/alteracaoEmLotes.componentes/CampoDinamico.vue
@@ -1,0 +1,177 @@
+<script setup>
+import { onMounted, watch } from 'vue';
+import { Field, ErrorMessage } from 'vee-validate';
+import SmaeNumberInput from '@/components/camposDeFormulario/SmaeNumberInput.vue';
+import SmaeDateInput from '@/components/camposDeFormulario/SmaeDateInput.vue';
+
+const props = defineProps({
+  idx: Number,
+  config: Object,
+  modelValue: null,
+  errors: Object,
+  loadingOptions: Object,
+  storeInstances: Object,
+  fontesEstaticas: Object,
+  readonly: Boolean,
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+function updateValue(value) {
+  emit('update:modelValue', value);
+}
+
+async function fetchOptionsIfNeeded() {
+  const meta = props.config?.meta;
+  if (
+    props.config?.tipo !== 'select-dinamico'
+    || !meta?.storeKey
+    || !meta?.fetchAction
+    || (!meta.listState && !meta.getterKey)
+  ) return;
+
+  const store = props.storeInstances[meta.storeKey];
+  if (!store || typeof store[meta.fetchAction] !== 'function') return;
+
+  const dataKey = meta.getterKey || meta.listState;
+  if (Array.isArray(store[dataKey]) && store[dataKey].length > 0) return;
+
+  await store[meta.fetchAction]();
+}
+
+watch(() => props.config?.tipo, async (tipo) => {
+  if (tipo === 'select-dinamico') await fetchOptionsIfNeeded();
+});
+
+onMounted(() => {
+  if (props.config?.tipo === 'select-dinamico') {
+    fetchOptionsIfNeeded();
+  }
+});
+
+function getOptionsForField(config) {
+  const meta = config?.meta;
+  if (!meta) return [];
+
+  if (config.tipo === 'select-estatico') {
+    return props.fontesEstaticas?.[meta.optionSource] || [];
+  }
+
+  if (config.tipo === 'select-dinamico') {
+    const store = props.storeInstances[meta.storeKey];
+    const list = meta.getterKey ? store[meta.getterKey] : store[meta.listState];
+    if (!list || !Array.isArray(list)) return [];
+
+    const getLabel = typeof meta.optionLabel === 'function'
+      ? meta.optionLabel
+      : (item) => item[meta.optionLabel];
+
+    return list.map((item) => ({
+      value: item[meta.optionValue],
+      label: getLabel(item),
+    }));
+  }
+
+  return [];
+}
+</script>
+
+<template>
+  <SmaeNumberInput
+    v-if="config?.tipo === 'number'"
+    :name="`edicoes[${idx}].valor`"
+    :model-value="modelValue"
+    class="inputtext light"
+    :aria-readonly="readonly"
+    :readonly="readonly"
+    @update:modelValue="updateValue"
+  />
+
+  <Field
+    v-if="config?.tipo === 'text'"
+    :name="`edicoes[${idx}].valor`"
+    type="text"
+    class="inputtext light"
+    :aria-readonly="readonly"
+    :readonly="readonly"
+    :model-value="modelValue"
+    @update:modelValue="updateValue"
+  />
+
+  <SmaeDateInput
+    v-if="config?.tipo === 'date'"
+    :name="`edicoes[${idx}].valor`"
+    :model-value="modelValue"
+    class="inputtext light"
+    :aria-readonly="readonly"
+    :readonly="readonly"
+    @update:modelValue="updateValue"
+  />
+
+  <Field
+    v-if="config?.tipo === 'select-estatico'"
+    :name="`edicoes[${idx}].valor`"
+    as="select"
+    class="inputtext light"
+    :model-value="modelValue"
+    :aria-readonly="readonly"
+    @mousedown="readonly && $event.preventDefault()"
+    @keydown="readonly && $event.preventDefault()"
+    @focus="readonly && $event.target.blur()"
+    @update:modelValue="updateValue"
+  >
+    <option
+      value=""
+      disabled
+    >
+      Selecione...
+    </option>
+    <option
+      v-for="opcao in getOptionsForField(config)"
+      :key="opcao.value"
+      :value="opcao.value"
+    >
+      {{ opcao.label }}
+    </option>
+  </Field>
+
+  <div v-if="config?.tipo === 'select-dinamico'">
+    <div
+      v-if="loadingOptions?.[`${idx}-${config?.meta?.storeKey}`]"
+      class="inputtext light mb1 disabled-placeholder"
+    >
+      Carregando opções...
+    </div>
+    <Field
+      v-else
+      :name="`edicoes[${idx}].valor`"
+      as="select"
+      class="inputtext light"
+      :model-value="modelValue"
+      :aria-readonly="readonly"
+      @mousedown="readonly && $event.preventDefault()"
+      @keydown="readonly && $event.preventDefault()"
+      @focus="readonly && $event.target.blur()"
+      @update:modelValue="updateValue"
+    >
+      <option
+        value=""
+        disabled
+      >
+        Selecione...
+      </option>
+      <option
+        v-for="opcao in getOptionsForField(config)"
+        :key="opcao.value"
+        :value="opcao.value"
+      >
+        {{ opcao.label }}
+      </option>
+    </Field>
+  </div>
+
+  <ErrorMessage
+    class="error-msg"
+    :name="`edicoes[${idx}].valor`"
+  />
+</template>

--- a/frontend/src/components/camposDeFormulario/SmaeDateInput.vue
+++ b/frontend/src/components/camposDeFormulario/SmaeDateInput.vue
@@ -1,0 +1,78 @@
+<script setup>
+import { useField } from 'vee-validate';
+import {
+  computed,
+  toRef,
+} from 'vue';
+import { parseISO, isValid, format } from 'date-fns';
+
+const props = defineProps({
+  modelValue: {
+    type: [Date, String, null],
+    default: null,
+  },
+  name: {
+    type: String,
+    default: '',
+  },
+  converterPara: {
+    default: 'date',
+    type: String,
+    validator(valor) {
+      return ['date', 'string', 'text'].includes(valor);
+    },
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+const nome = toRef(props, 'name');
+
+const { handleChange } = useField(nome, undefined, {
+  // eslint-disable-next-line no-nested-ternary
+  initialValue: props.modelValue
+    ? (
+      ['string', 'text'].includes(props.converterPara.toLowerCase())
+        ? String(props.modelValue)
+        : new Date(props.modelValue)
+    )
+    : null,
+});
+
+const valorDigitado = computed({
+  get() {
+    if (!props.modelValue || props.modelValue === '') return null;
+
+    const data = props.modelValue instanceof Date
+      ? props.modelValue
+      : parseISO(props.modelValue);
+
+    return isValid(data) ? format(data, 'yyyy-MM-dd') : null;
+  },
+
+  set(novoValor) {
+    const estaVazio = novoValor === '' || novoValor === null;
+
+    let valorFinal = null;
+
+    if (!estaVazio) {
+      const data = parseISO(novoValor);
+      if (isValid(data)) {
+        valorFinal = ['string', 'text'].includes(props.converterPara.toLowerCase())
+          ? format(data, 'yyyy-MM-dd')
+          : data;
+      }
+    }
+
+    handleChange(valorFinal);
+    emit('update:modelValue', valorFinal);
+  },
+});
+</script>
+
+<template>
+  <input
+    v-model="valorDigitado"
+    type="date"
+    :name="nome"
+  >
+</template>

--- a/frontend/src/components/camposDeFormulario/SmaeNumberInput.vue
+++ b/frontend/src/components/camposDeFormulario/SmaeNumberInput.vue
@@ -1,0 +1,98 @@
+<script setup>
+import { useField } from 'vee-validate';
+import {
+  computed,
+  toRef,
+} from 'vue';
+
+const props = defineProps({
+  modelValue: {
+    type: [Number, String, null],
+    default: null,
+  },
+  name: {
+    type: String,
+    default: '',
+  },
+  converterPara: {
+    default: 'number',
+    type: String,
+    validator(valor) {
+      return ['number', 'string', 'text'].includes(valor);
+    },
+  },
+  max: {
+    type: Number,
+    default: 0,
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+const name = toRef(props, 'name');
+
+const validarValorMaximo = (max, value) => {
+  if (max > 0) {
+    return value >= max ? max : value;
+  }
+  return value;
+};
+
+const { handleChange } = useField(name, undefined, {
+  // eslint-disable-next-line no-nested-ternary
+  initialValue: props.modelValue
+    ? (
+      ['string', 'text'].includes(props.converterPara.toLowerCase())
+        ? String(props.modelValue)
+        : Number(props.modelValue)
+    )
+    : null,
+});
+
+const typedValue = computed({
+  get() {
+    return props.modelValue === '' || props.modelValue === null
+      ? null
+      : props.modelValue;
+  },
+  set(newValue) {
+    const isEmpty = newValue === '' || newValue === null;
+
+    const parseToNumber = (val) => {
+      if (typeof val === 'string') {
+        const numericString = val.replace(/[^\d,.-]/g, '').replace(',', '.');
+        const parsed = parseFloat(numericString);
+        return Number.isNaN(parsed) ? null : parsed;
+      }
+
+      return typeof val === 'number' ? val : null;
+    };
+
+    const convertIfNeeded = (val) => {
+      if (val === null) return null;
+
+      let result = validarValorMaximo(Number(props.max), val);
+      if (['string', 'text'].includes(props.converterPara.toLowerCase())) {
+        result = String(result);
+      }
+      return result;
+    };
+
+    const cleanValue = isEmpty
+      ? null
+      : convertIfNeeded(parseToNumber(newValue));
+
+    handleChange(cleanValue);
+    emit('update:modelValue', cleanValue);
+  },
+});
+</script>
+
+<template>
+  <input
+    v-model="typedValue"
+    pattern="[0-9]*"
+    type="text"
+    inputmode="numeric"
+    :name="name"
+  >
+</template>

--- a/frontend/src/consts/formSchemas.js
+++ b/frontend/src/consts/formSchemas.js
@@ -1476,7 +1476,12 @@ export const obras = object({
   previsao_termino: date()
     .label('Previsão de término')
     .max(dataMax)
-    .min(ref('previsao_inicio'), 'Precisa ser posterior à data de início')
+    .when('previsao_inicio', (inicio, schema) => {
+      if (inicio) {
+        return schema.min(inicio, 'Precisa ser posterior à data de início');
+      }
+      return schema;
+    })
     .nullable()
     .meta({ permite_edicao_em_massa: true }),
   programa_id: number()

--- a/frontend/src/consts/formSchemas.js
+++ b/frontend/src/consts/formSchemas.js
@@ -1243,7 +1243,15 @@ export const obras = object({
   equipamento_id: number()
     .label('Equipamento/Estrutura pública')
     .min(1, 'Equipamento/Estrutura pública inválida')
-    .nullable(),
+    .nullable()
+    .meta({
+      permite_edicao_em_massa: true,
+      storeKey: 'equipamentos',
+      fetchAction: 'buscarTudo',
+      listState: 'lista',
+      optionValue: 'id',
+      optionLabel: 'nome',
+    }),
   fonte_recursos: array()
     .label('Fontes de recursos')
     .nullable()
@@ -1294,7 +1302,15 @@ export const obras = object({
   grupo_tematico_id: number()
     .label('Grupo temático')
     .min(1, 'Grupo temático inválido')
-    .required(),
+    .required()
+    .meta({
+      permite_edicao_em_massa: true,
+      storeKey: 'grupos_tematicos',
+      fetchAction: 'buscarTudo',
+      listState: 'lista',
+      optionValue: 'id',
+      optionLabel: 'nome',
+    }),
   iniciativa_id: number()
     .when(['origem_tipo', 'atividade_id'], {
       is: (origemTipo, atividadeId) => origemTipo === 'PdmSistema' && atividadeId,
@@ -1304,29 +1320,37 @@ export const obras = object({
   mdo_detalhamento: string()
     .label('Detalhamento/Escopo da obra')
     .max(50000)
-    .nullable(),
+    .nullable()
+    .meta({ permite_edicao_em_massa: true }),
   mdo_n_familias_beneficiadas: number()
     .label('Número de famílias beneficiadas')
+    .nullable()
     .min(0)
-    .nullable(),
+    .meta({ permite_edicao_em_massa: true }),
   mdo_n_unidades_habitacionais: number()
     .label('Número de unidades')
     .min(0)
-    .nullable(),
+    .nullable()
+    .meta({ permite_edicao_em_massa: true }),
   mdo_n_unidades_atendidas: number()
     .label('Número de unidades atendidas até o momento')
     .min(0)
     .nullable()
-    .transform((v) => (v === '' || Number.isNaN(v) ? null : v)),
+    .transform((v) => (v === '' || Number.isNaN(v) ? null : v))
+    .meta({ permite_edicao_em_massa: true }),
   mdo_observacoes: string()
     .label('Observações')
     .max(1024)
-    .nullable(),
+    .nullable()
+    .meta({ permite_edicao_em_massa: true }),
   mdo_previsao_inauguracao: date()
     .label('Data de inauguração planejada')
     .max(dataMax)
     .min(dataMin)
-    .nullable(),
+    .nullable()
+    .transform((curr, orig) => (orig === '' ? null : curr))
+    .typeError('Informe uma data válida (AAAA-MM-DD)')
+    .meta({ permite_edicao_em_massa: true }),
   meta_codigo: string()
     .label('Código da Meta')
     .when(['origem_tipo'], {
@@ -1352,11 +1376,27 @@ export const obras = object({
   orgao_executor_id: number()
     .label('Secretaria/órgão executor')
     .min(1, 'Secretaria/órgão executor inválidos')
-    .nullable(),
+    .nullable()
+    .meta({
+      permite_edicao_em_massa: true,
+      storeKey: 'órgãos',
+      fetchAction: 'getAll',
+      listState: 'organs',
+      optionValue: 'id',
+      optionLabel: (item) => `${item.sigla} - ${item.descricao}`,
+    }),
   orgao_gestor_id: number()
     .label('Órgão gestor do portfólio')
     .min(1, 'Órgão inválido')
-    .required(),
+    .required()
+    .meta({
+      permite_edicao_em_massa: true,
+      storeKey: 'órgãos',
+      fetchAction: 'getAll',
+      listState: 'organs',
+      optionValue: 'id',
+      optionLabel: (item) => `${item.sigla} - ${item.descricao}`,
+    }),
   orgao_origem_id: number()
     .label('Secretaria/órgão de origem')
     .min(1, 'Secretaria/órgão de origem inválidos')
@@ -1364,7 +1404,15 @@ export const obras = object({
   orgao_responsavel_id: number()
     .label('Órgão responsável pela obra')
     .min(1, 'Órgão responsável pela obra inválidos')
-    .nullable(),
+    .nullable()
+    .meta({
+      permite_edicao_em_massa: true,
+      storeKey: 'órgãos',
+      fetchAction: 'getAll',
+      listState: 'organs',
+      optionValue: 'id',
+      optionLabel: (item) => `${item.sigla} - ${item.descricao}`,
+    }),
   orgaos_colaboradores: string()
     .label('Órgãos colaboradores da obra')
     .nullable(),
@@ -1423,12 +1471,14 @@ export const obras = object({
     .label('Previsão de início')
     .max(dataMax)
     .min(dataMin)
-    .nullable(),
+    .nullable()
+    .meta({ permite_edicao_em_massa: true }),
   previsao_termino: date()
     .label('Previsão de término')
     .max(dataMax)
     .min(ref('previsao_inicio'), 'Precisa ser posterior à data de início')
-    .nullable(),
+    .nullable()
+    .meta({ permite_edicao_em_massa: true }),
   programa_id: number()
     .label('Programa Habitacional')
     .positive()
@@ -1466,11 +1516,18 @@ export const obras = object({
     .nullable(),
   secretario: string()
     .label('Secretário gestor do portfólio')
-    .nullable(),
+    .nullable()
+    .meta({ permite_edicao_em_massa: true }),
   status: mixed()
     .label('Status')
     .oneOf(Object.keys(statusObras))
-    .required(),
+    .required()
+    .meta({
+      permite_edicao_em_massa: true,
+      optionSource: 'statusObras',
+      optionValue: 'value',
+      optionLabel: 'label',
+    }),
   tags: array()
     .label('Etiquetas')
     .of(
@@ -1481,7 +1538,15 @@ export const obras = object({
   tipo_intervencao_id: number()
     .label('Tipo de obra/intervenção')
     .min(1, 'Tipo de obra/intervenção inválido')
-    .required(),
+    .required()
+    .meta({
+      permite_edicao_em_massa: true,
+      storeKey: 'tipos_de_intervencao',
+      fetchAction: 'buscarTudo',
+      listState: 'lista',
+      optionValue: 'id',
+      optionLabel: 'nome',
+    }),
   tolerancia_atraso: number()
     .label('Percentual de tolerância com atraso')
     .min(0)

--- a/frontend/src/router/edicoesEmLote.js
+++ b/frontend/src/router/edicoesEmLote.js
@@ -71,7 +71,7 @@ export default {
               name: 'edicoesEmLoteObrasNovoConstruir',
               component: () => import('@/views/edicoesEmLote/obras/EdicoesEmLoteObrasConstruir.vue'),
               meta: {
-                rotaDeEscape: 'edicoesEmLoteObrasNovo',
+                rotaDeEscape: 'edicoesEmLoteObras',
               },
             },
             {

--- a/frontend/src/views/edicoesEmLote/EdicoesEmLoteResumo.vue
+++ b/frontend/src/views/edicoesEmLote/EdicoesEmLoteResumo.vue
@@ -1,4 +1,14 @@
-<script setup>
+<script setup lang="ts">
+import { useEdicoesEmLoteStore } from '@/stores/edicoesEmLote.store';
+import { storeToRefs } from 'pinia';
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+
+const edicoesEmLoteStore = useEdicoesEmLoteStore(route.meta.tipoDeAcoesEmLote as string);
+const { emFoco } = storeToRefs(edicoesEmLoteStore);
+
+edicoesEmLoteStore.buscarItem(route.params.edicaoEmLoteId as unknown as number);
 </script>
 <template>
   <CabecalhoDePagina />
@@ -6,4 +16,8 @@
   <p class="debug">
     Aqui carregamos os detalhes de uma edição criada.
   </p>
+
+  <pre>
+    emFoco: {{ emFoco }}
+  </pre>
 </template>

--- a/frontend/src/views/edicoesEmLote/obras/EdicoesEmLoteObrasConstruir.vue
+++ b/frontend/src/views/edicoesEmLote/obras/EdicoesEmLoteObrasConstruir.vue
@@ -1,11 +1,384 @@
 <script setup>
-// Aqui montamos a edição
+import * as yup from 'yup';
+import { useEdicoesEmLoteStore } from '@/stores/edicoesEmLote.store';
+import {
+  Field, FieldArray, ErrorMessage, useForm,
+} from 'vee-validate';
+import { computed, ref } from 'vue';
+import { useAlertStore } from '@/stores/alert.store';
+import { useEquipamentosStore } from '@/stores/equipamentos.store';
+import { useGruposTematicosStore } from '@/stores/gruposTematicos.store';
+import { useOrgansStore } from '@/stores/organs.store';
+import { useTiposDeIntervencaoStore } from '@/stores/tiposDeIntervencao.store';
+import rawStatusObras from '@/consts/statusObras';
+import { obras as schemaObras } from '@/consts/formSchemas';
+import LabelFromYup from '@/components/camposDeFormulario/LabelFromYup.vue';
+import CabecalhoDePagina from '@/components/CabecalhoDePagina.vue';
+import CampoDinamico from '@/components/alteracaoEmLotes.componentes/CampoDinamico.vue';
+import SmaeFieldsetSubmit from '@/components/SmaeFieldsetSubmit.vue';
+import { useRoute, useRouter } from 'vue-router';
+
+const router = useRouter();
+const route = useRoute();
+const alertStore = useAlertStore();
+const edicoesEmLoteStore = useEdicoesEmLoteStore(route.meta.tipoDeAcoesEmLote);
+
+const modoRevisao = ref(false);
+
+const storeInstances = {
+  equipamentos: useEquipamentosStore(),
+  grupos_tematicos: useGruposTematicosStore(),
+  órgãos: useOrgansStore(),
+  tipos_de_intervencao: useTiposDeIntervencaoStore(),
+};
+
+const fontesEstaticas = {
+  statusObras: Object.values(rawStatusObras).map((item) => ({
+    value: item.valor,
+    label: item.nome,
+  })),
+};
+
+const loadingOptions = ref({});
+
+const schema = yup.object({
+  edicoes: yup.array().of(
+    yup.object({
+      propriedade: yup.string().required('Selecione o campo'),
+      valor: yup.lazy((value, { parent }) => {
+        const { propriedade } = parent;
+        if (!propriedade) {
+          return yup.mixed().nullable();
+        }
+        const campoSchemaOriginal = schemaObras.fields[propriedade];
+
+        if (!campoSchemaOriginal) {
+          return yup.mixed().required('Configuração inválida.');
+        }
+        return campoSchemaOriginal.required('Informe o novo valor');
+      }),
+    }),
+  ).min(1, 'Adicione pelo menos uma edição'),
+});
+
+const {
+  values, errors, handleSubmit, setFieldValue,
+} = useForm({
+  validationSchema: schema,
+  initialValues: {
+    edicoes: [],
+  },
+});
+
+const camposDisponiveisParaEdicao = computed(() => Object.entries(schemaObras.fields)
+  .filter(([_, fieldSchema]) => fieldSchema.meta()?.permite_edicao_em_massa)
+  .map(([fieldName, fieldSchema]) => ({
+    value: fieldName,
+    label: fieldSchema.spec.label || fieldName,
+  })));
+
+function getOpcoesDisponiveis(rowIndex) {
+  const propriedadesSelecionadas = values.edicoes
+    ?.map((edicao, index) => (index !== rowIndex ? edicao.propriedade : null))
+    .filter((prop) => prop != null && prop !== '');
+
+  return camposDisponiveisParaEdicao.value.filter(
+    (opcao) => !propriedadesSelecionadas.includes(opcao.value),
+  );
+}
+
+function detectarTipoCampo(campoSchema, meta) {
+  if (meta.optionSource && fontesEstaticas[meta.optionSource]) {
+    return 'select-estatico';
+  }
+
+  if (meta.storeKey) {
+    return 'select-dinamico';
+  }
+
+  const tipoPorClasse = {
+    NumberSchema: 'number',
+    StringSchema: 'text',
+    ArraySchema: 'array',
+    DateSchema: 'date',
+    ObjectSchema: 'object',
+  };
+
+  const nomeDaClasse = campoSchema.constructor.name;
+  return tipoPorClasse[nomeDaClasse] || 'text';
+}
+
+function obterConfiguracaoCampo(nomeCampo) {
+  const campoSchema = schemaObras.fields[nomeCampo];
+  if (!campoSchema) return null;
+
+  const meta = campoSchema.meta?.() || {};
+  const tipo = detectarTipoCampo(campoSchema, meta);
+
+  return {
+    schema: campoSchema,
+    tipo,
+    label: campoSchema.spec?.label || nomeCampo,
+    meta,
+  };
+}
+
+function campoConfig(idx) {
+  const prop = values.edicoes?.[idx]?.propriedade;
+  return prop ? obterConfiguracaoCampo(prop) : null;
+}
+
+const onSubmit = handleSubmit(async (valores) => {
+  if (!modoRevisao.value) {
+    modoRevisao.value = true;
+    return;
+  }
+
+  const payload = {
+    tipo: route.meta.tipoDeAcoesEmLote,
+    ids: edicoesEmLoteStore.idsSelecionados,
+    ops: valores.edicoes.map((edicao) => ({
+      col: edicao.propriedade,
+      set: String(edicao.valor),
+    })),
+  };
+
+  try {
+    if (await edicoesEmLoteStore.salvarItem(payload)) {
+      alertStore.success('Edição realizada com sucesso.');
+
+      const rotaDeEscape = route.meta?.rotaDeEscape;
+
+      if (rotaDeEscape) {
+        router.push(typeof rotaDeEscape === 'string' ? { name: rotaDeEscape } : rotaDeEscape);
+      }
+    }
+  } catch (error) {
+    alertStore.error(error);
+  }
+});
+
+async function fetchOptionsIfNeeded(rowIndex, fieldConfig) {
+  const { meta } = fieldConfig;
+  if (!meta?.storeKey || !meta.fetchAction || (!meta.listState && !meta.getterKey)) {
+    console.warn('Configuração de metadados incompleta:', fieldConfig);
+    return;
+  }
+
+  const store = storeInstances[meta.storeKey];
+  if (!store) {
+    console.error(`Store não encontrada para a chave: ${meta.storeKey}`);
+    return;
+  }
+
+  const dataSourceKey = meta.getterKey || meta.listState;
+
+  if (
+    store[dataSourceKey]
+      && Array.isArray(store[dataSourceKey]) && store[dataSourceKey].length > 0) {
+    return;
+  }
+
+  const loadingKey = `${rowIndex}-${meta.storeKey}`;
+  if (loadingOptions.value[loadingKey]) {
+    return;
+  }
+
+  loadingOptions.value = { ...loadingOptions.value, [loadingKey]: true };
+
+  try {
+    if (typeof store[meta.fetchAction] !== 'function') {
+      throw new Error(`Ação '${meta.fetchAction}' não encontrada na store ${meta.storeKey}`);
+    }
+    await store[meta.fetchAction]();
+  } catch (error) {
+    console.error(`Erro ao buscar dados para ${meta.storeKey}:`, error);
+  } finally {
+    loadingOptions.value = { ...loadingOptions.value, [loadingKey]: false };
+  }
+}
+
+function handlePropertyChange(event, idx) {
+  const propriedadeSelecionada = event.target.value;
+  setFieldValue(`edicoes[${idx}].valor`, null);
+
+  if (propriedadeSelecionada) {
+    const fieldConfig = obterConfiguracaoCampo(propriedadeSelecionada);
+    if (fieldConfig?.tipo === 'select-dinamico' && fieldConfig.meta?.storeKey) {
+      fetchOptionsIfNeeded(idx, fieldConfig);
+    }
+  }
+}
 </script>
 
 <template>
   <CabecalhoDePagina />
-
-  <p class="debug">
-    Aqui montamos a edição.
+  <p v-if="modoRevisao">
+    Essa alteração será aplicada nas
+    {{ edicoesEmLoteStore.idsSelecionados.length }} obras selecionadas. Confirma a edição?
   </p>
+  <p v-else>
+    Selecione o item que deseja editar nas
+    {{ edicoesEmLoteStore.idsSelecionados.length }} obras selecionadas.
+  </p>
+  <form @submit.prevent="onSubmit">
+    <div class="mb2">
+      <FieldArray
+        v-slot="{ fields, push, remove }"
+        name="edicoes"
+      >
+        <div
+          v-for="(field, idx) in fields"
+          :key="field.key"
+          class="flex g2 mb1 items-start"
+        >
+          <div class="f1">
+            <LabelFromYup
+              :name="`edicoes[${idx}].propriedade`"
+              label="Editar"
+              class="tc300"
+            >
+              Editar
+            </LabelFromYup>
+            <Field
+              :name="`edicoes[${idx}].propriedade`"
+              as="select"
+              class="inputtext light mb1"
+              :class="{ error: errors?.[`edicoes[${idx}].propriedade`] }"
+              :aria-disabled="modoRevisao"
+              @mousedown="modoRevisao && $event.preventDefault()"
+              @keydown="modoRevisao && $event.preventDefault()"
+              @focus="modoRevisao && $event.target.blur()"
+              @change="(event) => handlePropertyChange(event, idx)"
+            >
+              <option
+                value=""
+                disabled
+              >
+                Selecione...
+              </option>
+              <option
+                v-for="opcao in getOpcoesDisponiveis(idx)"
+                :key="opcao.value"
+                :value="opcao.value"
+              >
+                {{ opcao.label }}
+              </option>
+            </Field>
+            <ErrorMessage
+              class="error-msg"
+              :name="`edicoes[${idx}].propriedade`"
+            />
+          </div>
+
+          <div class="f1">
+            <template v-if="values.edicoes?.[idx]?.propriedade">
+              <LabelFromYup
+                :name="`edicoes[${idx}].valor`"
+                class="tc300"
+              >
+                {{ campoConfig(idx).label || 'Valor' }}
+              </LabelFromYup>
+              <CampoDinamico
+                v-model="values.edicoes[idx].valor"
+                :idx="idx"
+                :config="campoConfig(idx)"
+                :errors="errors"
+                :loading-options="loadingOptions"
+                :store-instances="storeInstances"
+                :fontes-estaticas="fontesEstaticas"
+                :readonly="modoRevisao"
+              />
+            </template>
+            <template v-else>
+              <div class="label tc300">
+                Selecione
+              </div>
+              <div class="inputtext light mb1 disabled-placeholder">
+                Selecione um campo à esquerda
+              </div>
+              <ErrorMessage
+                class="error-msg"
+                :name="`edicoes[${idx}].valor`"
+              />
+            </template>
+          </div>
+
+          <button
+            v-if="!modoRevisao"
+            type="button"
+            class="like-a__text addlink self-end mb-1"
+            aria-label="Remover Edição"
+            title="Remover Edição"
+            @click="remove(idx)"
+          >
+            <svg
+              width="20"
+              height="20"
+            ><use xlink:href="#i_remove" /></svg>
+          </button>
+        </div>
+
+        <button
+          v-if="!modoRevisao"
+          class="like-a__text addlink"
+          type="button"
+          @click="push({ propriedade: '', valor: null })"
+        >
+          <svg
+            width="20"
+            height="20"
+          ><use xlink:href="#i_+" /></svg>Adicionar Edição
+        </button>
+      </FieldArray>
+      <ErrorMessage
+        name="edicoes"
+        class="error-msg mt1"
+      />
+    </div>
+
+    <SmaeFieldsetSubmit>
+      <template v-if="!modoRevisao">
+        <button
+          type="submit"
+          class="btn big"
+          :disabled="Object.keys(errors).length > 0 || values.edicoes?.length === 0"
+        >
+          Aplicar Edição
+        </button>
+      </template>
+
+      <template v-else>
+        <button
+          type="button"
+          class="btn big outline bgnone tcprimary"
+          @click="modoRevisao = false"
+        >
+          Retornar
+        </button>
+        <button
+          type="submit"
+          class="btn big"
+          @click="confirmarEdicao"
+        >
+          Confirmar Edição
+        </button>
+      </template>
+    </SmaeFieldsetSubmit>
+  </form>
 </template>
+
+<style scoped>
+.disabled-placeholder {
+  color: #aaa;
+  background-color: #f9f9f9;
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: 4px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+}
+</style>

--- a/frontend/src/views/edicoesEmLote/obras/EdicoesEmLoteObrasConstruir.vue
+++ b/frontend/src/views/edicoesEmLote/obras/EdicoesEmLoteObrasConstruir.vue
@@ -1,5 +1,11 @@
 <script setup>
-import * as yup from 'yup';
+import {
+  object,
+  array,
+  string,
+  mixed,
+  lazy,
+} from 'yup';
 import { useEdicoesEmLoteStore } from '@/stores/edicoesEmLote.store';
 import {
   Field, FieldArray, ErrorMessage, useForm,
@@ -41,19 +47,19 @@ const fontesEstaticas = {
 
 const loadingOptions = ref({});
 
-const schema = yup.object({
-  edicoes: yup.array().of(
-    yup.object({
-      propriedade: yup.string().required('Selecione o campo'),
-      valor: yup.lazy((value, { parent }) => {
+const schema = object({
+  edicoes: array().of(
+    object({
+      propriedade: string().required('Selecione o campo'),
+      valor: lazy((value, { parent }) => {
         const { propriedade } = parent;
         if (!propriedade) {
-          return yup.mixed().nullable();
+          return mixed().nullable();
         }
         const campoSchemaOriginal = schemaObras.fields[propriedade];
 
         if (!campoSchemaOriginal) {
-          return yup.mixed().required('Configuração inválida.');
+          return mixed().required('Configuração inválida.');
         }
         return campoSchemaOriginal.required('Informe o novo valor');
       }),
@@ -139,7 +145,7 @@ const onSubmit = handleSubmit(async (valores) => {
     ids: edicoesEmLoteStore.idsSelecionados,
     ops: valores.edicoes.map((edicao) => ({
       col: edicao.propriedade,
-      set: String(edicao.valor),
+      set: edicao.valor,
     })),
   };
 
@@ -148,6 +154,7 @@ const onSubmit = handleSubmit(async (valores) => {
       alertStore.success('Edição realizada com sucesso.');
 
       const rotaDeEscape = route.meta?.rotaDeEscape;
+      await edicoesEmLoteStore.limparIdsSelecionados();
 
       if (rotaDeEscape) {
         router.push(typeof rotaDeEscape === 'string' ? { name: rotaDeEscape } : rotaDeEscape);


### PR DESCRIPTION

- Cria componente CampoDinamico.vue para renderização dinâmica de inputs conforme o tipo
- Adiciona suporte a campos estáticos e dinâmicos (selects, datas, números e textos)
- Implementa modo de revisão com campos bloqueados
- Monta payload compatível para o backend
- Integra submissão com edicoesEmLoteStore e alertas de sucesso/erro
- Adiciona diversos campos no formSchema com metadados para edição em lote