### PR TITLE
Feature/sa6.mo002 ajuste pf responsavel

### DIFF
--- a/frontend/src/components/CampoDePessoasComBuscaPorOrgao.vue
+++ b/frontend/src/components/CampoDePessoasComBuscaPorOrgao.vue
@@ -47,6 +47,10 @@ const props = defineProps({
     type: String,
     default: 'Órgão',
   },
+  pessoasLabel: {
+    type: String,
+    default: 'Pessoas',
+  },
   // necessária para que o vee-validate não se perca
   name: {
     type: String,
@@ -93,7 +97,11 @@ const props = defineProps({
     type: Boolean,
     default: undefined,
   },
-  textoInformativo: {
+  orgaoInformativo: {
+    type: String,
+    default: undefined,
+  },
+  pessoaInformativo: {
     type: String,
     default: undefined,
   },
@@ -269,8 +277,8 @@ watch(
         >
           {{ props.orgaoLabel }}
           <SmaeTooltip
-            v-if="$props.textoInformativo"
-            :texto="$props.textoInformativo"
+            v-if="$props.orgaoInformativo"
+            :texto="$props.orgaoInformativo"
           />
         </label>
 
@@ -300,7 +308,14 @@ watch(
         <label
           :for="`${$props.name}__pessoas--${idx}`"
           class="label"
-        >Pessoas</label>
+        >
+          {{ $props.pessoasLabel }}
+          <SmaeTooltip
+            v-if="$props.pessoaInformativo"
+            :texto="$props.pessoaInformativo"
+          />
+        </label>
+
         <AutocompleteField
           :id="`${$props.name}__pessoas--${idx}`"
           :controlador="{

--- a/frontend/src/components/alteracaoEmLotes.componentes/CampoDinamico.vue
+++ b/frontend/src/components/alteracaoEmLotes.componentes/CampoDinamico.vue
@@ -236,12 +236,7 @@ const maxLength = computed(() => props.config?.schema?.tests?.find((test) => tes
       @focus="readonly && $event.target.blur()"
       @update:modelValue="updateValue"
     >
-      <option
-        value=""
-        disabled
-      >
-        Selecione...
-      </option>
+      <option value="" disabled>Selecione...</option>
       <option
         v-for="opcao in getOptionsForField(config)"
         :key="opcao.value"

--- a/frontend/src/components/alteracaoEmLotes.componentes/CampoDinamico.vue
+++ b/frontend/src/components/alteracaoEmLotes.componentes/CampoDinamico.vue
@@ -196,6 +196,7 @@ const maxLength = computed(() => props.config?.schema?.tests?.find((test) => tes
       :readonly="readonly"
       :limitar-para-um-orgao="true"
       :numero-maximo-de-participantes="config?.meta?.numeroMaximoDeParticipantes"
+      :pessoa-informativo="config?.meta?.balaoInformativo"
       @update:modelValue="updateValue"
     />
 
@@ -235,7 +236,12 @@ const maxLength = computed(() => props.config?.schema?.tests?.find((test) => tes
       @focus="readonly && $event.target.blur()"
       @update:modelValue="updateValue"
     >
-      <option value="" disabled>Selecione...</option>
+      <option
+        value=""
+        disabled
+      >
+        Selecione...
+      </option>
       <option
         v-for="opcao in getOptionsForField(config)"
         :key="opcao.value"

--- a/frontend/src/consts/formEdicaoEmLoteObras.js
+++ b/frontend/src/consts/formEdicaoEmLoteObras.js
@@ -94,6 +94,7 @@ const metasEdicaoEmLote = {
         Set: 'Substitui o item existente.',
       },
     },
+    balaoInformativo: 'É a pessoa responsável pela evolução da obra em todas as suas fases. Suas principais funções incluem acompanhar o andamento da obra e do(s) respectivo(s) contrato(s), mantendo as informações atualizadas no SMAE.',
   },
   portfolios_compartilhados: {
     permite_edicao_em_massa: true,
@@ -148,6 +149,7 @@ const metasEdicaoEmLote = {
         Remove: 'Exclui o item selecionado da obra',
       },
     },
+    balaoInformativo: 'É a pessoa que atua como facilitador e apoiador na aplicação das metodologias definidas. Suas principais responsabilidades incluem fornecer suporte técnico e metodológico ao Ponto Focal Responsável, durante todas as fases.',
   },
   secretario_executivo: {
     permite_edicao_em_massa: true,

--- a/frontend/src/consts/formSchemas.js
+++ b/frontend/src/consts/formSchemas.js
@@ -1250,7 +1250,10 @@ export const obras = object({
       number()
         .min(1),
     )
-    .nullable(),
+    .nullable()
+    .meta({
+      balaoInformativo: 'É a pessoa responsável por apoiar o Ponto Focal Responsável na atualização das informações da obra no SMAE.',
+    }),
   empreendimento_id: number()
     .label('Identificador do empreendimento')
     .min(1, 'Empreendimento inválido')
@@ -1424,10 +1427,7 @@ export const obras = object({
     .nullable(),
   ponto_focal_responsavel: string()
     .label('Ponto focal responsável')
-    .nullableOuVazio()
-    .meta({
-      balaoInformativo: 'É a pessoa responsável por apoiar o Ponto Focal Responsável na atualização das informações da obra no SMAE.',
-    }),
+    .nullableOuVazio(),
   portfolios_compartilhados: array()
     .label('Compartilhar com portfólios')
     .nullable(),

--- a/frontend/src/consts/formSchemas.js
+++ b/frontend/src/consts/formSchemas.js
@@ -1250,10 +1250,7 @@ export const obras = object({
       number()
         .min(1),
     )
-    .nullable()
-    .meta({
-      balaoInformativo: 'É a pessoa responsável por apoiar o Ponto Focal Responsável na atualização das informações da obra no SMAE.',
-    }),
+    .nullable(),
   empreendimento_id: number()
     .label('Identificador do empreendimento')
     .min(1, 'Empreendimento inválido')
@@ -1427,7 +1424,10 @@ export const obras = object({
     .nullable(),
   ponto_focal_responsavel: string()
     .label('Ponto focal responsável')
-    .nullableOuVazio(),
+    .nullableOuVazio()
+    .meta({
+      balaoInformativo: 'É a pessoa responsável por apoiar o Ponto Focal Responsável na atualização das informações da obra no SMAE.',
+    }),
   portfolios_compartilhados: array()
     .label('Compartilhar com portfólios')
     .nullable(),

--- a/frontend/src/views/mdo.obras/ObraCriarEditar.vue
+++ b/frontend/src/views/mdo.obras/ObraCriarEditar.vue
@@ -1535,9 +1535,10 @@ watch(listaDeTiposDeIntervenção, () => {
           :model-value="values.colaboradores_no_orgao"
           :valores-iniciais="itemParaEdicao.colaboradores_no_orgao"
           name="colaboradores_no_orgao"
-          orgao-label="Órgão Colaborador"
+          :orgao-label="schema.fields.colaboradores_no_orgao.spec.label"
+          :pessoas-label="schema.fields.ponto_focal_responsavel.spec.label"
           :pessoas="possíveisResponsáveisPorÓrgãoId[values.orgao_colaborador_id] || []"
-          :texto-informativo="schema.fields.colaboradores_no_orgao.meta().balaoInformativo"
+          :pessoa-informativo="schema.fields.colaboradores_no_orgao.meta().balaoInformativo"
         />
       </div>
     </fieldset>

--- a/frontend/src/views/mdo.obras/ObraCriarEditar.vue
+++ b/frontend/src/views/mdo.obras/ObraCriarEditar.vue
@@ -1536,7 +1536,7 @@ watch(listaDeTiposDeIntervenção, () => {
           :valores-iniciais="itemParaEdicao.colaboradores_no_orgao"
           name="colaboradores_no_orgao"
           :orgao-label="schema.fields.colaboradores_no_orgao.spec.label"
-          :pessoas-label="schema.fields.ponto_focal_responsavel.spec.label"
+          :pessoas-label="schema.fields.ponto_focal_colaborador.spec.label"
           :pessoas="possíveisResponsáveisPorÓrgãoId[values.orgao_colaborador_id] || []"
           :pessoa-informativo="schema.fields.colaboradores_no_orgao.meta().balaoInformativo"
         />


### PR DESCRIPTION
[Task ID](https://trello.com/c/Kcdtqd71/2133-sa6mo002-incluir-icone-de-informacao-em-campos)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added customizable labels and independent informational tooltips for "Órgão" and "Pessoas" fields, allowing for greater flexibility and clarity in forms.
- **Enhancements**
  - Labels and tooltips for relevant fields are now dynamically sourced from configuration or schema, improving adaptability and user guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->