### PR TITLE
Feat/alertar na troca de status

### DIFF
--- a/frontend/src/components/AlertModal.vue
+++ b/frontend/src/components/AlertModal.vue
@@ -38,6 +38,7 @@ async function callbackFn(i) {
         </div>
         <template v-if="alert.type == 'confirmAction'">
           <button
+            type="button"
             class="btn amarelo mr1"
             @click="callbackFn(i)"
           >
@@ -75,6 +76,8 @@ async function callbackFn(i) {
         </template>
         <button
           v-else
+          v-focus
+          type="button"
           class="btn amarelo"
           @click="alertas.splice(i, 1)"
         >

--- a/frontend/src/views/mdo.obras/ObraCriarEditar.vue
+++ b/frontend/src/views/mdo.obras/ObraCriarEditar.vue
@@ -194,6 +194,12 @@ const {
   validationSchema: schema,
 });
 
+function alertarTrocaDeStatus() {
+  if (!!itemParaEdicao.value.status && itemParaEdicao.value.status !== values.status) {
+    alertStore.success('Lembre-se de atualizar a etapa do cronograma');
+  }
+}
+
 function BuscarDotaçãoParaAno(valorOuEvento) {
   const ano = valorOuEvento.target?.value || valorOuEvento;
 
@@ -507,9 +513,11 @@ watch(listaDeTiposDeIntervenção, () => {
           as="select"
           class="inputtext light mb1"
           :class="{ error: errors.status }"
+          @change.once="alertarTrocaDeStatus"
         >
           <option
             :value="null"
+            disabled
           >
             Selecionar
           </option>

--- a/frontend/src/views/projetos/ProjetosCriarEditar.vue
+++ b/frontend/src/views/projetos/ProjetosCriarEditar.vue
@@ -158,6 +158,12 @@ const possíveisOrigens = [
   },
 ];
 
+function alertarTrocaDeStatus() {
+  if (!!itemParaEdicao.value.status && itemParaEdicao.value.status !== values.status) {
+    alertStore.success('Lembre-se de atualizar a etapa do cronograma');
+  }
+}
+
 function BuscarDotaçãoParaAno(valorOuEvento) {
   const ano = valorOuEvento.target?.value || valorOuEvento;
 
@@ -414,6 +420,7 @@ watch(itemParaEdicao, (novoValor) => {
             desabilitarTodosCampos.camposComuns
               || !emFoco?.permissoes.status_permitidos?.length
           "
+          @change.once="alertarTrocaDeStatus"
         >
           <option :value="null">
             Selecionar


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added alerts to notify users when changing the status in the "Obra" and "Projeto" forms, reminding them to update the schedule or stage accordingly.

- **Bug Fixes**
  - Improved accessibility and behavior of alert modal buttons by explicitly setting their type and ensuring the default button gains focus automatically.
  - Disabled the default "Selecionar" option in status dropdowns to prevent accidental selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->