### PR TITLE
fix: Trazer de volta os textos explicativos de relatórios, mas agora …

### DIFF
--- a/frontend/src/views/relatorios/NovoMensal.vue
+++ b/frontend/src/views/relatorios/NovoMensal.vue
@@ -15,10 +15,9 @@ import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
 // eslint-disable-next-line import/no-cycle
 import { useTagsStore } from '@/stores/tags.store';
 import { storeToRefs } from 'pinia';
-import { Field, Form } from 'vee-validate';
+import { Field, Form, useIsFormDirty } from 'vee-validate';
 import { onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import CheckClose from '../../components/CheckClose.vue';
 
 const TagsStore = useTagsStore();
 const { filtradasPorPdM } = storeToRefs(TagsStore);
@@ -30,6 +29,8 @@ const relatoriosStore = useRelatoriosStore();
 const route = useRoute();
 const router = useRouter();
 const { loading } = storeToRefs(relatoriosStore);
+
+const formularioSujo = useIsFormDirty();
 
 const initialValues = ref({
   fonte: 'MonitoramentoMensal',
@@ -88,11 +89,13 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="flex spacebetween center mb2">
-    <h1>{{ $route.meta.título || $route.name }}</h1>
-    <hr class="ml2 f1">
-    <CheckClose />
-  </div>
+  <CabecalhoDePagina :formulario-sujo="formularioSujo" />
+
+  <p class="texto--explicativo">
+    Será gerado um conjunto de 4 planilhas contendo os dados
+    do ciclo mensal de monitoramento físico do mês informado.
+  </p>
+
   <Form
     v-slot="{ errors, isSubmitting, resetField, values }"
     :validation-schema="schema"

--- a/frontend/src/views/relatorios/NovoOrcamentarioPdM.vue
+++ b/frontend/src/views/relatorios/NovoOrcamentarioPdM.vue
@@ -7,16 +7,17 @@ import { useAlertStore } from '@/stores/alert.store';
 // eslint-disable-next-line import/no-cycle
 import { usePdMStore } from '@/stores/pdm.store';
 import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
-import { Field, Form } from 'vee-validate';
+import { Field, Form, useIsFormDirty } from 'vee-validate';
 import { computed, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import CheckClose from '../../components/CheckClose.vue';
 
 const alertStore = useAlertStore();
 const PdMStore = usePdMStore();
 const relatoriosStore = useRelatoriosStore();
 const route = useRoute();
 const router = useRouter();
+
+const formularioSujo = useIsFormDirty();
 
 const initialValues = computed(() => ({
   fonte: 'Orcamento',
@@ -60,11 +61,14 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="flex spacebetween center mb2">
-    <h1>{{ $route.meta.título || $route.name }}</h1>
-    <hr class="ml2 f1">
-    <CheckClose />
-  </div>
+  <CabecalhoDePagina :formulario-sujo="formularioSujo" />
+
+  <p class="texto--explicativo">
+    Serão geradas 2 planilhas contendo os registros de execução orçamentária e do
+    orçamento planejado. A versão analítica retorna todos os registros e a
+    versão consolidada retorna somente o valor vigente no momento.
+  </p>
+
   <Form
     v-slot="{ errors, isSubmitting }"
     :validation-schema="schema"

--- a/frontend/src/views/relatorios/NovoRelatorioDePrevisaoDeCustoPdM.vue
+++ b/frontend/src/views/relatorios/NovoRelatorioDePrevisaoDeCustoPdM.vue
@@ -12,10 +12,9 @@ import { useRelatoriosStore } from '@/stores/relatorios.store.ts';
 // eslint-disable-next-line import/no-cycle
 import { useTagsStore } from '@/stores/tags.store';
 import { storeToRefs } from 'pinia';
-import { Field, Form } from 'vee-validate';
+import { Field, Form, useIsFormDirty } from 'vee-validate';
 import { computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import CheckClose from '../../components/CheckClose.vue';
 
 const alertStore = useAlertStore();
 const PdMStore = usePdMStore();
@@ -38,6 +37,8 @@ const iniciativasPorId = computed(() => (Array.isArray(metaSimplificada.value?.i
   : {}));
 
 const currentYear = new Date().getFullYear();
+
+const formularioSujo = useIsFormDirty();
 
 const initialValues = computed(() => ({
   fonte: 'PrevisaoCusto',
@@ -111,11 +112,13 @@ iniciar();
 </script>
 
 <template>
-  <div class="flex spacebetween center mb2">
-    <h1>{{ $route.meta.título || $route.name }}</h1>
-    <hr class="ml2 f1">
-    <CheckClose />
-  </div>
+  <CabecalhoDePagina :formulario-sujo="formularioSujo" />
+
+  <p class="texto--explicativo">
+    Será gerada uma planilha contendo os registros de previsão de custo
+    registrados nas metas
+  </p>
+
   <Form
     v-slot="{ errors, isSubmitting, resetField, setFieldValue, values }"
     :validation-schema="schema"

--- a/frontend/src/views/relatorios/NovoRelatorioDePrevisaoDeCustoPlanosSetoriais.vue
+++ b/frontend/src/views/relatorios/NovoRelatorioDePrevisaoDeCustoPlanosSetoriais.vue
@@ -1,6 +1,5 @@
 <script setup>
 import AutocompleteField from '@/components/AutocompleteField2.vue';
-import TituloDaPagina from '@/components/TituloDaPagina.vue';
 import { relatórioDePrevisãoDeCustoPlanosSetoriais as schema } from '@/consts/formSchemas';
 import truncate from '@/helpers/texto/truncate';
 import { useAlertStore } from '@/stores/alert.store';
@@ -115,13 +114,12 @@ iniciar();
 </script>
 
 <template>
-  <header class="flex spacebetween center mb2">
-    <TituloDaPagina />
+  <CabecalhoDePagina :formulario-sujo="formularioSujo" />
 
-    <hr class="ml2 f1">
-
-    <CheckClose :formulario-sujo="formularioSujo" />
-  </header>
+  <p class="texto--explicativo">
+    Será gerada uma planilha contendo os registros de previsão de custo
+    registrados nas metas
+  </p>
 
   <Form
     v-slot="{ errors, isSubmitting, resetField, setFieldValue, values }"

--- a/frontend/src/views/relatorios/NovoRelatorioOrcamentarioPlanosSetoriais.vue
+++ b/frontend/src/views/relatorios/NovoRelatorioOrcamentarioPlanosSetoriais.vue
@@ -1,5 +1,4 @@
 <script setup>
-import TituloDaPagina from '@/components/TituloDaPagina.vue';
 import { relatórioOrçamentárioPlanosSetoriais as schema } from '@/consts/formSchemas';
 import dateIgnorarTimezone from '@/helpers/dateIgnorarTimezone';
 import maskMonth from '@/helpers/maskMonth';
@@ -59,13 +58,13 @@ PlanosSetoriaisStore.buscarTudo();
 </script>
 
 <template>
-  <header class="flex spacebetween center mb2">
-    <TituloDaPagina />
+  <CabecalhoDePagina :formulario-sujo="formularioSujo" />
 
-    <hr class="ml2 f1">
-
-    <CheckClose :formulario-sujo="formularioSujo" />
-  </header>
+  <p class="texto--explicativo">
+    Serão geradas 2 planilhas contendo os registros de execução orçamentária e do
+    orçamento planejado. A versão analítica retorna todos os registros e a
+    versão consolidada retorna somente o valor vigente no momento.
+  </p>
 
   <Form
     v-slot="{ errors, isSubmitting }"

--- a/frontend/src/views/relatorios/NovoSemestralOuAnual.vue
+++ b/frontend/src/views/relatorios/NovoSemestralOuAnual.vue
@@ -1,6 +1,5 @@
 <script setup>
 import AutocompleteField from '@/components/AutocompleteField2.vue';
-import TituloDaPagina from '@/components/TituloDaPagina.vue';
 import { relatórioSemestralOuAnual as schema } from '@/consts/formSchemas';
 import { useAlertStore } from '@/stores/alert.store';
 import { storeToRefs } from 'pinia';
@@ -85,13 +84,15 @@ onMounted(async () => {
 </script>
 
 <template>
-  <header class="flex spacebetween center mb2">
-    <TituloDaPagina />
+  <CabecalhoDePagina :formulario-sujo="formularioSujo" />
 
-    <hr class="ml2 f1">
-
-    <CheckClose :formulario-sujo="formularioSujo" />
-  </header>
+  <p class="texto--explicativo">
+    Será gerado um conjunto de 2 planilhas contendo os indicadores da meta e de
+    seus desdobramentos e valores das variáveis regionalizadas. A versão
+    analítica retorna todos os valores das séries, desde o inicio da medição até
+    o periodo informado, e a consolidada somente os valores consolidados do
+    final de cada semestre/ano.
+  </p>
 
   <Form
     v-slot="{ errors, isSubmitting, values }"

--- a/frontend/src/views/relatorios/planosSetoriais/NovoMensalPS.vue
+++ b/frontend/src/views/relatorios/planosSetoriais/NovoMensalPS.vue
@@ -1,6 +1,5 @@
 <script setup>
 import AutocompleteField from '@/components/AutocompleteField2.vue';
-import TituloDaPagina from '@/components/TituloDaPagina.vue';
 import { useAlertStore } from '@/stores/alert.store';
 import { usePlanosSimplificadosStore } from '@/stores/planosMetasSimplificados.store';
 import { usePlanosSetoriaisStore } from '@/stores/planosSetoriais.store.ts';
@@ -16,6 +15,8 @@ import { useRoute, useRouter } from 'vue-router';
 import { relatórioMensalPS as schema } from '@/consts/formSchemas';
 import months from '@/consts/months';
 import nulificadorTotal from '@/helpers/nulificadorTotal';
+// Mantendo comportamento legado
+// eslint-disable-next-line import/no-cycle
 import { useTagsStore } from '@/stores/tags.store';
 
 const route = useRoute();
@@ -75,13 +76,13 @@ if (!listaDePlanosDisponiveis.value.length) {
 }
 </script>
 <template>
-  <header class="flex spacebetween center mb2">
-    <TituloDaPagina />
+  <CabecalhoDePagina :formulario-sujo="formularioSujo" />
 
-    <hr class="ml2 f1">
-
-    <CheckClose :formulario-sujo="formularioSujo" />
-  </header>
+  <p class="texto--explicativo">
+    Será gerado um conjunto de 4 planilhas, contendo os dados
+    do ciclo mensal de monitoramento físico do mês informado, considerando
+    somente as variáveis que estiverem LIBERADAS.
+  </p>
 
   <Form
     v-slot="{ errors, isSubmitting, resetField, values }"


### PR DESCRIPTION
…nas telas de criação

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified and simplified the header section across multiple report creation pages for a more consistent appearance.
- **Documentation**
  - Added explanatory text to report creation pages, clarifying the contents and purpose of the generated spreadsheets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->