### PR TITLE
Feature/sa7 gp002 ajuste permissoes edicao projetos

### DIFF
--- a/frontend/src/views/projetos/ProjetosCriarEditar.vue
+++ b/frontend/src/views/projetos/ProjetosCriarEditar.vue
@@ -130,16 +130,16 @@ const orgaosDisponiveisPorPortolio = computed(() => portfolioStore.lista.reduce(
 const desabilitarTodosCampos = computed(() => {
   const permissoes = emFoco.value?.permissoes || null;
 
-  if (!permissoes?.apenas_leitura) {
+  if (permissoes?.apenas_leitura) {
     return {
-      camposComuns: false,
-      camposGestor: false,
+      camposComuns: true,
+      camposGestor: permissoes?.pode_editar_apenas_responsaveis_pos_planejamento,
     };
   }
 
   return {
-    camposComuns: true,
-    camposGestor: permissoes?.pode_editar_apenas_responsaveis_pos_planejamento,
+    camposComuns: false,
+    camposGestor: false,
   };
 });
 
@@ -1352,7 +1352,7 @@ watch(itemParaEdicao, (novoValor) => {
               loading: ÓrgãosStore.organs.loading,
             }"
             :disabled="
-              desabilitarTodosCampos.camposGestor
+              desabilitarTodosCampos.camposComuns
                 || !orgaosDisponiveisPorPortolio[values.portfolio_id]?.length
             "
             @change="setFieldValue('responsaveis_no_orgao_gestor', [])"
@@ -1406,7 +1406,7 @@ watch(itemParaEdicao, (novoValor) => {
               loading: portfolioStore.chamadasPendentes.lista
             }"
             label="nome_exibicao"
-            :readonly="desabilitarTodosCampos.camposGestor"
+            :readonly="desabilitarTodosCampos.camposComuns"
           />
           <ErrorMessage
             name="responsaveis_no_orgao_gestor"
@@ -1431,7 +1431,7 @@ watch(itemParaEdicao, (novoValor) => {
               loading: portfolioStore.chamadasPendentes.lista
             }"
             :disabled="
-              desabilitarTodosCampos.camposGestor
+              desabilitarTodosCampos.camposComuns
                 || !órgãosQueTemResponsáveis?.length
             "
             @change="setFieldValue('responsavel_id', 0)"
@@ -1472,7 +1472,7 @@ watch(itemParaEdicao, (novoValor) => {
               loading: portfolioStore.chamadasPendentes.lista
             }"
             :disabled="
-              desabilitarTodosCampos.camposGestor
+              desabilitarTodosCampos.camposComuns
                 || !possíveisResponsáveisPorÓrgãoId[values.orgao_responsavel_id]?.length
             "
             @update:model-value="values.responsavel_id = Number(values.responsavel_id)


### PR DESCRIPTION
[Task ID](https://trello.com/c/58xklJat/2197-sa7gp002-gestao-de-projetos-perfil-de-gerente-de-projeto-deve-poder-editar-a-equipe-do-projeto-sempre-est%C3%A1-bloqueando-ap%C3%B3s-plane)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated field enable/disable logic in the project creation and editing form to better reflect user permissions, ensuring fields are correctly enabled or disabled based on read-only access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->