### PR TITLE
Fix/dialogo nao abre de dentro de outro

### DIFF
--- a/frontend/src/components/AlertModal/AlertModal.spec.ts
+++ b/frontend/src/components/AlertModal/AlertModal.spec.ts
@@ -128,7 +128,7 @@ describe('AlertModal', () => {
 
     await nextTick();
 
-    const dialogos = envelope.findAll('dialog');
+    let dialogos = envelope.findAll('dialog');
     expect(dialogos).toHaveLength(5);
     expect(dialogos[4].attributes('open')).toBeDefined();
     expect(dialogos[4].classes()).toContain('alert-success');
@@ -137,6 +137,7 @@ describe('AlertModal', () => {
     await dialogos[4].get('[data-test="aceite"]').trigger('click');
     await nextTick();
 
+    dialogos = envelope.findAll('dialog');
     expect(envelope.findAll('dialog')).toHaveLength(4);
     expect(dialogos[3].attributes('open')).toBeDefined();
     expect(dialogos[2].attributes('open')).toBeUndefined();
@@ -154,7 +155,7 @@ describe('AlertModal', () => {
     expect(dialogo.attributes('open')).toBeDefined();
     expect(dialogo.classes()).toContain('confirm');
 
-    const linkDeAceite = envelope.findComponent(RouterLinkStub);
+    const linkDeAceite = dialogo.findComponent(RouterLinkStub);
     expect(linkDeAceite.props().to).toBe('#teste');
   });
 
@@ -171,7 +172,7 @@ describe('AlertModal', () => {
     const dialogo = envelope.get('dialog');
     expect(dialogo.attributes('open')).toBeDefined();
     expect(dialogo.classes()).toContain('confirm');
-    const botaoDeAceite = envelope.get('[data-test="aceite"]');
+    const botaoDeAceite = dialogo.get('[data-test="aceite"]');
 
     await nextTick();
 
@@ -184,7 +185,7 @@ describe('AlertModal', () => {
     expect(envelope.find('dialog').exists()).toBe(false);
   });
 
-  it('exibe um diálogo de confirmação com função de secundária', async () => {
+  it('exibe um diálogo de confirmação com função secundária', async () => {
     const spyCallback = vi.fn();
     const spyFallback = vi.fn();
 
@@ -198,8 +199,8 @@ describe('AlertModal', () => {
     const dialogo = envelope.get('dialog');
     expect(dialogo.attributes('open')).toBeDefined();
     expect(dialogo.classes()).toContain('confirmAction');
-    const botaoDeAceite = envelope.get('[data-test="aceite"]');
-    const botaoDeEscape = envelope.get('[data-test="escape"]');
+    const botaoDeAceite = dialogo.get('[data-test="aceite"]');
+    const botaoDeEscape = dialogo.get('[data-test="escape"]');
 
     expect(botaoDeAceite.text()).toBe('aceitar');
 

--- a/frontend/src/components/AlertModal/AlertModal.spec.ts
+++ b/frontend/src/components/AlertModal/AlertModal.spec.ts
@@ -234,6 +234,8 @@ describe('AlertModal', () => {
 
     await botaoDeEscape.trigger('click');
 
+    await nextTick();
+
     expect(spyCallback).not.toHaveBeenCalled();
     expect(spyFallback).toHaveBeenCalled();
 
@@ -281,7 +283,12 @@ describe('AlertModal', () => {
 
     await nextTick();
 
-    const dialogos = envelope.findAll('dialog');
+    let dialogos = envelope.findAll('dialog');
+    expect(dialogos).toHaveLength(2);
+
+    await nextTick();
+
+    dialogos = envelope.findAll('dialog');
 
     expect(dialogos).toHaveLength(1);
     expect(dialogos[0].get('[data-test="mensagem"]').text()).toBe('Segundo diálogo!');

--- a/frontend/src/components/AlertModal/AlertModal.vue
+++ b/frontend/src/components/AlertModal/AlertModal.vue
@@ -25,7 +25,8 @@ async function removerAlerta(i) {
       dialogos.value[i].close();
     }
 
-    nextTick().then(alertas.value.splice(i, 1));
+    await nextTick();
+    alertas.value.splice(i, 1);
   }
 }
 
@@ -34,7 +35,8 @@ async function callbackFn(i) {
     await alertas.value[i].callback();
   }
 
-  nextTick().then(removerAlerta(i));
+  await nextTick();
+  removerAlerta(i);
 }
 
 async function fallbackFn(i) {
@@ -42,7 +44,8 @@ async function fallbackFn(i) {
     await alertas.value[i].fallback();
   }
 
-  nextTick().then(removerAlerta(i));
+  await nextTick();
+  removerAlerta(i);
 }
 
 watch(ultimoDialogo, (novoDialogo) => {

--- a/frontend/src/components/AlertModal/AlertModal.vue
+++ b/frontend/src/components/AlertModal/AlertModal.vue
@@ -19,15 +19,13 @@ const dialogos = ref([]);
 
 const ultimoDialogo = computed(() => dialogos.value[dialogos.value.length - 1]);
 
-async function fecharAlerta(i) {
+async function removerAlerta(i) {
   if (dialogos.value[i]) {
     if (typeof dialogos.value[i].close === 'function' && dialogos.value[i].open) {
       dialogos.value[i].close();
     }
 
-    await nextTick();
-
-    alertas.value.splice(i, 1);
+    nextTick().then(alertas.value.splice(i, 1));
   }
 }
 
@@ -36,15 +34,15 @@ async function callbackFn(i) {
     await alertas.value[i].callback();
   }
 
-  fecharAlerta(i);
+  nextTick().then(removerAlerta(i));
 }
 
 async function fallbackFn(i) {
   if (typeof alertas.value[i]?.fallback === 'function') {
-    alertas.value[i].fallback();
+    await alertas.value[i].fallback();
   }
 
-  fecharAlerta(i);
+  nextTick().then(removerAlerta(i));
 }
 
 watch(ultimoDialogo, (novoDialogo) => {
@@ -64,13 +62,13 @@ watch(ultimoDialogo, (novoDialogo) => {
   >
     <div
       v-for="(alert, i) in alertas"
-      :key="i"
+      :key="alert.id || i"
       class="alert-wrap"
     >
       <div
         class="overlay"
         @click="['alert-danger', 'alert-success'].indexOf(alert.type) > -1
-          ? fecharAlerta(i)
+          ? removerAlerta(i)
           : null"
       />
       <dialog
@@ -78,7 +76,7 @@ watch(ultimoDialogo, (novoDialogo) => {
         class="alert"
         :class="alert.type"
         :aria-busy="estaCarregando"
-        @close="fecharAlerta(i)"
+        @close.prevent
       >
         <div
           class="alert-message"
@@ -112,7 +110,7 @@ watch(ultimoDialogo, (novoDialogo) => {
             :to="alert.url"
             class="btn amarelo mr1"
             data-test="aceite"
-            @click="fecharAlerta(i)"
+            @click="removerAlerta(i)"
           >
             Sair sem salvar
           </router-link>
@@ -122,14 +120,14 @@ watch(ultimoDialogo, (novoDialogo) => {
             type="button"
             class="btn amarelo mr1"
             data-test="aceite"
-            @click="alert.url(); fecharAlerta(i);"
+            @click="alert.url(); removerAlerta(i);"
           >
             Sair sem salvar
           </button>
           <button
             class="btn amarelo outline"
             data-test="escape"
-            @click="fecharAlerta(i)"
+            @click="removerAlerta(i)"
           >
             Cancelar
           </button>
@@ -140,7 +138,7 @@ watch(ultimoDialogo, (novoDialogo) => {
           type="button"
           class="btn amarelo"
           data-test="aceite"
-          @click="fecharAlerta(i)"
+          @click="removerAlerta(i)"
         >
           OK
         </button>

--- a/frontend/src/helpers/texto/gerarId.ts
+++ b/frontend/src/helpers/texto/gerarId.ts
@@ -1,0 +1,1 @@
+export default () => crypto?.randomUUID() || `${Date.now()}-${Math.random().toString(36).substring(2)}`;

--- a/frontend/src/stores/alert.store.js
+++ b/frontend/src/stores/alert.store.js
@@ -1,3 +1,4 @@
+import gerarId from '@/helpers/texto/gerarId';
 import { defineStore } from 'pinia';
 
 export const useAlertStore = defineStore('alert', {
@@ -11,7 +12,7 @@ export const useAlertStore = defineStore('alert', {
     },
     success(message) {
       this.alertas.push({
-        id: crypto?.randomUUID(),
+        id: gerarId(),
         message,
         type: 'alert-success',
       });
@@ -19,14 +20,14 @@ export const useAlertStore = defineStore('alert', {
     error(message, ignorarDuplicadas = true) {
       if (ignorarDuplicadas && this.alertas.some((v) => v.message === message && v.type === 'alert-danger')) return;
       this.alertas.push({
-        id: crypto?.randomUUID(),
+        id: gerarId(),
         message,
         type: 'alert-danger',
       });
     },
     confirm(message, url) {
       this.alertas.push({
-        id: crypto?.randomUUID(),
+        id: gerarId(),
         message,
         url,
         type: 'confirm',
@@ -34,7 +35,7 @@ export const useAlertStore = defineStore('alert', {
     },
     confirmAction(message, callback, label, fallback) {
       this.alertas.push({
-        id: crypto?.randomUUID(),
+        id: gerarId(),
         message,
         callback,
         type: 'confirmAction',

--- a/frontend/src/stores/alert.store.js
+++ b/frontend/src/stores/alert.store.js
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 
-export const useAlertStore = defineStore('alert',{
+export const useAlertStore = defineStore('alert', {
   state: () => ({
     alertas: [],
     estaCarregando: false,
@@ -10,18 +10,36 @@ export const useAlertStore = defineStore('alert',{
       this.estaCarregando = value;
     },
     success(message) {
-      this.alertas.push({ message, type: 'alert-success' });
+      this.alertas.push({
+        id: crypto?.randomUUID(),
+        message,
+        type: 'alert-success',
+      });
     },
     error(message, ignorarDuplicadas = true) {
       if (ignorarDuplicadas && this.alertas.some((v) => v.message === message && v.type === 'alert-danger')) return;
-      this.alertas.push({ message, type: 'alert-danger' });
+      this.alertas.push({
+        id: crypto?.randomUUID(),
+        message,
+        type: 'alert-danger',
+      });
     },
     confirm(message, url) {
-      this.alertas.push({ message, url, type: 'confirm' });
+      this.alertas.push({
+        id: crypto?.randomUUID(),
+        message,
+        url,
+        type: 'confirm',
+      });
     },
     confirmAction(message, callback, label, fallback) {
       this.alertas.push({
-        message, callback, type: 'confirmAction', label: label ?? 'OK', fallback: fallback ?? false,
+        id: crypto?.randomUUID(),
+        message,
+        callback,
+        type: 'confirmAction',
+        label: label ?? 'OK',
+        fallback: fallback ?? false,
       });
     },
     clear() { // TODO: remover função desnecessária. Pode-se usar `.$reset();`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Alerts now include unique identifiers, improving handling and rendering of multiple alerts.
- **Bug Fixes**
	- Prevented duplicate error dialogs from appearing when multiple identical error messages are triggered.
- **Refactor**
	- Improved alert removal logic for better reliability and deferred execution.
	- Enhanced key usage in alert lists for more stable UI rendering.
	- Disabled default dialog close event to better control alert dismissal.
- **Tests**
	- Expanded test coverage for dialog deduplication and confirmation dialogs that trigger subsequent dialogs.
	- Improved test clarity and selector precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->