### PR TITLE
feat(parlamentar): adiciona gestão de comparecimento eleitoral e recá…

### DIFF
--- a/backend/src/parlamentar/dto/create-parlamentar.dto.ts
+++ b/backend/src/parlamentar/dto/create-parlamentar.dto.ts
@@ -206,9 +206,8 @@ export class CreateMandatoRepresentatividadeDto {
     @ValidateIf((object, value) => value !== null)
     pct_participacao?: number;
 
-    @IsOptional()
     @IsNumber()
-    ranking?: number;
+    ranking: number;
 }
 
 export class CreateMandatoBancadaDto {

--- a/backend/src/parlamentar/dto/eleicao-comparecimento.dto.ts
+++ b/backend/src/parlamentar/dto/eleicao-comparecimento.dto.ts
@@ -1,0 +1,42 @@
+import { DadosEleicaoNivel } from '@prisma/client';
+import { Transform, TransformFnParams } from 'class-transformer';
+import { IsEmpty, IsNotEmpty, IsNumber, IsOptional, ValidateIf } from 'class-validator';
+
+export class GetEleicaoComparecimentoDto {
+    @IsOptional()
+    @IsNumber()
+    @Transform((a: TransformFnParams) => (a.value === '' ? undefined : +a.value))
+    eleicao_id?: number;
+
+    @IsOptional()
+    @IsNumber()
+    @Transform((a: TransformFnParams) => (a.value === '' ? undefined : +a.value))
+    mandato_id?: number;
+
+    @ValidateIf((o) => !o.eleicao_id && !o.mandato_id)
+    @IsNotEmpty({ message: 'Deve ser informado eleicao_id ou mandato_id' })
+    _validation?: any;
+
+    @ValidateIf((o) => o.eleicao_id && o.mandato_id)
+    @IsEmpty({ message: 'Deve ser informado apenas eleicao_id OU mandato_id' })
+    _validation2?: any;
+}
+
+export class EleicaoComparecimentoDto {
+    eleicao_id: number;
+    comparecimentos: {
+        regiao_id: number;
+        regiao_nome: string;
+        nivel: DadosEleicaoNivel;
+        valor: number;
+        parlamentares_count: number;
+    }[];
+}
+
+export class ComparecimentoConflictResponseDto {
+    conflict_detected: true;
+    comparecimento_existente: number;
+    novo_comparecimento: number;
+    parlamentares_afetados: number;
+    message: string;
+}

--- a/backend/src/parlamentar/dto/update-parlamentar.dto.ts
+++ b/backend/src/parlamentar/dto/update-parlamentar.dto.ts
@@ -1,4 +1,5 @@
 import { OmitType, PartialType } from '@nestjs/swagger';
+import { IsBoolean, IsNumber, IsOptional } from 'class-validator';
 import {
     CreateEquipeDto,
     CreateMandatoDto,
@@ -18,6 +19,14 @@ export class UpdateRepresentatividadeDto extends PartialType(
         'municipio_tipo',
         'nivel',
         'regiao_id',
-        'numero_comparecimento',
+        'pct_participacao',
     ])
-) {}
+) {
+    @IsOptional()
+    @IsNumber()
+    numero_comparecimento?: number;
+
+    @IsOptional()
+    @IsBoolean()
+    confirma_alteracao_comparecimento?: boolean;
+}

--- a/backend/src/parlamentar/parlamentar.controller.ts
+++ b/backend/src/parlamentar/parlamentar.controller.ts
@@ -23,6 +23,11 @@ import {
 import { FilterParlamentarDto } from './dto/filter-parlamentar.dto';
 import { PaginatedDto } from 'src/common/dto/paginated.dto';
 import { ApiPaginatedResponse } from 'src/auth/decorators/paginated.decorator';
+import {
+    EleicaoComparecimentoDto,
+    GetEleicaoComparecimentoDto,
+    ComparecimentoConflictResponseDto,
+} from './dto/eleicao-comparecimento.dto';
 
 @ApiTags('Parlamentar')
 @Controller('parlamentar')
@@ -141,6 +146,16 @@ export class ParlamentarController {
         return '';
     }
 
+    @Get('/eleicao-comparecimento')
+    @ApiBearerAuth('access-token')
+    @Roles(['CadastroParlamentar.inserir'])
+    async getEleicaoComparecimento(
+        @Query() query: GetEleicaoComparecimentoDto,
+        @CurrentUser() user: PessoaFromJwt
+    ): Promise<EleicaoComparecimentoDto> {
+        return await this.parlamentarService.getEleicaoComparecimento(query, user);
+    }
+
     // Mandato - Representatividade
     @Post(':id/representatividade')
     @ApiBearerAuth('access-token')
@@ -160,7 +175,7 @@ export class ParlamentarController {
         @Param() params: FindTwoParams,
         @Body() dto: UpdateRepresentatividadeDto,
         @CurrentUser() user: PessoaFromJwt
-    ): Promise<RecordWithId> {
+    ): Promise<RecordWithId | ComparecimentoConflictResponseDto> {
         return await this.parlamentarService.updateMandatoRepresentatividade(+params.id2, dto, user);
     }
 


### PR DESCRIPTION
…lculo automático de percentuais

Implementa endpoints e DTOs para consulta e atualização de comparecimento eleitoral por eleição/região, com recálculo automático dos percentuais de participação dos parlamentares afetados; adiciona detecção de conflitos ao alterar comparecimento, exige ranking obrigatório e melhora validações e mensagens de erro para maior integridade e clareza dos dados.