### PR TITLE
fix: gerar planejado.csv mesmo sem correspondência em filtroMetas

### DIFF
--- a/backend/src/reports/orcamento/orcamento.service.ts
+++ b/backend/src/reports/orcamento/orcamento.service.ts
@@ -210,7 +210,9 @@ export class OrcamentoService implements ReportableService {
         }
         if (dto.portfolio_id) {
             // restringe a itens vinculados a algum projeto e pertencentes ao portfólio (direto ou compartilhado)
-            baseWhere.projeto_id = { not: null };
+            if (!baseWhere.projeto_id) {
+                baseWhere.projeto_id = { not: null };
+            }
             baseWhere.AND = [
                 ...(baseWhere.AND ?? []),
                 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - More reliable budget search: meta filters are applied only when matching metas exist, preventing accidental exclusions.
  - Improved portfolio filtering: results now include items tied to projects when a portfolio is specified.

- Refactor
  - Consolidated query construction for more consistent, predictable filtering across searches.

- Chores
  - Removed an unused dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->