### PR TITLE
refactor: Reorganizar `input[type='range']`

### DIFF
--- a/frontend/src/components/camposDeFormulario/SmaeDoubleRangeInput.md
+++ b/frontend/src/components/camposDeFormulario/SmaeDoubleRangeInput.md
@@ -1,0 +1,401 @@
+# Documentação do Componente SmaeDoubleRangeInput
+
+## Visão Geral
+
+`SmaeDoubleRangeInput` é um componente de entrada dupla de intervalo (dual range slider) que permite aos usuários selecionar valores mínimos e máximos dentro de um range específico. O componente integra-se com VeeValidate para validação de formulários e oferece opções de formatação monetária, inputs de texto editáveis e sincronização bidirecional.
+
+## Props
+
+### `nameMin` (obrigatória)
+
+- **Tipo:** `string`
+- **Descrição:** Nome do campo para o valor mínimo. Usado pelo VeeValidate para gerenciar o estado do campo.
+
+### `nameMax` (obrigatória)
+
+- **Tipo:** `string`
+- **Descrição:** Nome do campo para o valor máximo. Usado pelo VeeValidate para gerenciar o estado do campo.
+
+### `min`
+
+- **Tipo:** `number`
+- **Padrão:** `0`
+- **Descrição:** Valor mínimo permitido para o range.
+
+### `max`
+
+- **Tipo:** `number`
+- **Padrão:** `100`
+- **Descrição:** Valor máximo permitido para o range.
+
+### `step`
+
+- **Tipo:** `number | null`
+- **Padrão:** `null`
+- **Descrição:** Incremento dos valores. Se `null`, usa `0.01` como padrão para permitir valores decimais precisos.
+
+### `formatarMoeda`
+
+- **Tipo:** `boolean`
+- **Padrão:** `true`
+- **Descrição:** Quando `true`, formata os valores como moeda brasileira (R$). Quando `false`, exibe valores numéricos simples.
+
+### `precision`
+
+- **Tipo:** `number`
+- **Padrão:** `3`
+- **Descrição:** Número de casas decimais para cálculos internos de posicionamento dos sliders. Não afeta a exibição dos valores.
+
+### `mostrarInputs`
+
+- **Tipo:** `boolean`
+- **Padrão:** `false`
+- **Descrição:** Quando `true`, exibe campos de texto editáveis abaixo dos sliders para entrada manual de valores. Quando `false`, exibe apenas labels formatados.
+
+## Como Usar
+
+### Exemplo Básico
+
+```vue
+<template>
+  <form>
+    <label>Faixa de Preço</label>
+    <SmaeDoubleRangeInput
+      name-min="preco_min"
+      name-max="preco_max"
+      :min="0"
+      :max="10000"
+    />
+  </form>
+</template>
+
+<script setup>
+import SmaeDoubleRangeInput from '@/components/camposDeFormulario/SmaeDoubleRangeInput.vue';
+</script>
+```
+
+### Exemplo com Inputs Editáveis
+
+```vue
+<SmaeDoubleRangeInput
+  name-min="valor_min"
+  name-max="valor_max"
+  :min="0"
+  :max="100000"
+  :mostrar-inputs="true"
+/>
+```
+
+Permite que o usuário ajuste os valores tanto pelos sliders quanto digitando diretamente nos campos de texto.
+
+### Exemplo sem Formatação Monetária
+
+```vue
+<SmaeDoubleRangeInput
+  name-min="quantidade_min"
+  name-max="quantidade_max"
+  :min="0"
+  :max="1000"
+  :formatar-moeda="false"
+/>
+```
+
+Exibe valores numéricos simples sem o símbolo R$ e formatação de moeda.
+
+### Exemplo com Step Customizado
+
+```vue
+<SmaeDoubleRangeInput
+  name-min="peso_min"
+  name-max="peso_max"
+  :min="0"
+  :max="500"
+  :step="0.5"
+  :formatar-moeda="false"
+/>
+```
+
+Define incrementos de 0.5 para ajustes mais precisos.
+
+### Integração com VeeValidate e Yup
+
+```vue
+<template>
+  <Form @submit="onSubmit" :validation-schema="schema">
+    <SmaeDoubleRangeInput
+      name-min="valor_min"
+      name-max="valor_max"
+      :min="0"
+      :max="10000"
+      :mostrar-inputs="true"
+    />
+    <button type="submit">Filtrar</button>
+  </Form>
+</template>
+
+<script setup>
+import { Form } from 'vee-validate';
+import * as Yup from 'yup';
+
+const schema = Yup.object({
+  valor_min: Yup.number().min(0).required(),
+  valor_max: Yup.number().max(10000).required(),
+});
+
+function onSubmit(values) {
+  console.log('Valores:', values.valor_min, values.valor_max);
+}
+</script>
+```
+
+### Exemplo com FormularioQueryString
+
+```vue
+<template>
+  <FormularioQueryString
+    v-slot="{ aplicarQueryStrings }"
+    :valores-iniciais="{}"
+  >
+    <form @submit.prevent="aplicarQueryStrings">
+      <SmaeDoubleRangeInput
+        name-min="preco_min"
+        name-max="preco_max"
+        :min="0"
+        :max="50000"
+        :mostrar-inputs="true"
+      />
+      <button type="submit">Pesquisar</button>
+    </form>
+  </FormularioQueryString>
+</template>
+```
+
+Os valores dos sliders serão automaticamente incluídos nos query parameters da URL.
+
+## Comportamento
+
+### Sincronização Bidirecional
+
+1. **Sliders → VeeValidate:** Quando o usuário move os sliders, os valores são atualizados no VeeValidate automaticamente
+2. **VeeValidate → Sliders:** Se os valores forem alterados externamente (ex: via `setFieldValue`), os sliders se ajustam
+3. **Inputs de Texto ↔ Sliders:** Quando `mostrarInputs` está ativo, edições nos inputs atualizam os sliders e vice-versa
+
+### Prevenção de Colisão dos Thumbs
+
+O componente usa algoritmo inteligente para evitar que os thumbs (controles deslizantes) se sobreponham:
+
+- Quando o slider mínimo se aproxima do máximo, o ponto médio é calculado usando `Math.ceil`
+- Quando o slider máximo se aproxima do mínimo, o ponto médio é calculado usando `Math.floor`
+- Isso cria uma separação mínima entre os thumbs
+
+### Gradiente de Preenchimento
+
+O componente exibe um gradiente visual que indica o range selecionado:
+
+- Parte cinza clara: valores fora do range selecionado
+- Parte colorida: valores dentro do range selecionado
+- O gradiente é calculado dinamicamente com compensação do tamanho do thumb para precisão visual
+
+### Formatação de Valores
+
+#### Com `formatarMoeda={true}` (padrão):
+
+- **Labels/Inputs:** `R$ 1.234,56` (formato brasileiro)
+- **Inputs editáveis:** Aceita entrada com vírgula como separador decimal
+- **Validação:** Converte automaticamente formato brasileiro para número
+
+#### Com `formatarMoeda={false}`:
+
+- **Labels/Inputs:** `1234.56` (número simples)
+- **Inputs editáveis:** Aceita apenas números e ponto decimal
+
+### Inputs Ocultos para Formulários
+
+O componente sempre renderiza inputs `hidden` com os valores atuais:
+
+```html
+<input type="hidden" name="valor_min" value="1000">
+<input type="hidden" name="valor_max" value="5000">
+```
+
+Isso garante que os valores sejam submetidos com o formulário, mesmo quando os sliders não estão visíveis.
+
+## Acessibilidade
+
+### Labels ARIA
+
+O componente usa labels ARIA contextuais para melhor experiência com leitores de tela:
+
+#### Quando `mostrarInputs={false}`:
+- Slider mínimo: `aria-label="Valor mínimo"`
+- Slider máximo: `aria-label="Valor máximo"`
+
+#### Quando `mostrarInputs={true}`:
+- Slider mínimo: `aria-label="Slider valor mínimo"`
+- Slider máximo: `aria-label="Slider valor máximo"`
+- Input mínimo: `aria-label="Valor mínimo"`
+- Input máximo: `aria-label="Valor máximo"`
+
+A diferenciação evita confusão quando múltiplos controles estão visíveis simultaneamente.
+
+### Navegação por Teclado
+
+- **Setas ←/→:** Ajusta o valor do slider em foco pelo `step` definido
+- **Setas ↑/↓:** Ajusta o valor do slider em foco pelo `step` definido
+- **PageUp/PageDown:** Ajusta o valor em incrementos maiores (10× `step`)
+- **Home:** Define o valor como `min`
+- **End:** Define o valor como `max`
+- **Tab:** Move o foco entre controles
+
+## Integração com Helpers
+
+### Helper `dinheiro`
+
+Usado para formatação de valores monetários:
+
+```javascript
+import dinheiro from '@/helpers/dinheiro';
+
+// Formatação para exibição
+dinheiro(1234.56, { style: 'currency', currency: 'BRL' });
+// Retorna: "R$ 1.234,56"
+
+// Formatação para inputs editáveis
+dinheiro(1234.56, { style: 'decimal' });
+// Retorna: "1.234,56"
+```
+
+### Helper `toFloat`
+
+Usado para converter strings para números, suportando formato brasileiro:
+
+```javascript
+import toFloat from '@/helpers/toFloat';
+
+toFloat('1.234,56'); // 1234.56
+toFloat('1234.56');  // 1234.56
+toFloat('R$ 1.234,56'); // 1234.56
+```
+
+## Estilização
+
+O componente usa variáveis CSS customizadas para estilização dinâmica:
+
+```css
+.smae-range-input {
+  --thumb-width: 20px;
+  --track-height: 4px;
+  --gradient-position: calc(50% + (0 * var(--thumb-width)));
+}
+```
+
+### Classes Disponíveis
+
+- `.smae-range-input`: Container principal
+- `.range-wrapper`: Wrapper dos sliders com flexbox
+- `.range-input`: Input range individual
+- `.range-labels`: Container para labels quando `mostrarInputs={false}`
+- `.range-inputs`: Container para inputs editáveis quando `mostrarInputs={true}`
+- `.input-prefix`: Prefixo "R$" nos inputs editáveis
+
+## Notas Técnicas
+
+### Precisão Decimal
+
+- O componente usa `step={0.01}` por padrão para suportar valores monetários com centavos
+- Para evitar problemas de arredondamento com ponto flutuante, todos os cálculos internos usam a `precision` configurável
+- Valores são sempre arredondados para o `step` mais próximo
+
+### Flexbox Layout
+
+O componente usa flexbox ao invés de `position: absolute` para posicionamento dos sliders:
+
+```css
+.range-input:first-child {
+  flex-basis: calc(50% + var(--thumb-width));
+}
+
+.range-input:last-child {
+  flex-basis: calc(50% + var(--thumb-width));
+}
+```
+
+Isso garante:
+- Layout responsivo sem cálculos JavaScript complexos
+- Melhor performance de renderização
+- Menos bugs de posicionamento
+
+### Z-Index Dinâmico
+
+O slider em foco recebe `z-index: 2` para aparecer acima do outro, facilitando interações em ranges pequenos.
+
+## Limitações Conhecidas
+
+### Navegadores Antigos
+
+- Requer suporte a `<input type="range">` (IE 10+)
+- Usa CSS Grid e Flexbox (IE 11+ com prefixos)
+- Usa `Math.min/Math.max` extensivamente
+
+### Safari
+
+- A estilização de `<input type="range">` pode ter pequenas diferenças visuais
+- Thumbs podem ter tamanho ligeiramente diferente
+
+### Performance
+
+- Em ranges muito grandes (ex: `min=0, max=1000000`), a sensibilidade do slider pode ser reduzida
+- Recomenda-se usar `step` apropriado para a escala dos valores
+
+## Exemplos de Casos de Uso
+
+### Filtro de Preços em E-commerce
+
+```vue
+<SmaeDoubleRangeInput
+  name-min="preco_min"
+  name-max="preco_max"
+  :min="0"
+  :max="10000"
+  :mostrar-inputs="true"
+/>
+```
+
+### Filtro de Área (m²) em Imóveis
+
+```vue
+<SmaeDoubleRangeInput
+  name-min="area_min"
+  name-max="area_max"
+  :min="20"
+  :max="500"
+  :step="5"
+  :formatar-moeda="false"
+/>
+```
+
+### Filtro de Salário em Vagas
+
+```vue
+<SmaeDoubleRangeInput
+  name-min="salario_min"
+  name-max="salario_max"
+  :min="1320"
+  :max="50000"
+  :step="100"
+/>
+```
+
+### Filtro de Quantidade de Produtos
+
+```vue
+<SmaeDoubleRangeInput
+  name-min="qtd_min"
+  name-max="qtd_max"
+  :min="1"
+  :max="100"
+  :step="1"
+  :formatar-moeda="false"
+  :mostrar-inputs="true"
+/>
+```

--- a/frontend/src/components/camposDeFormulario/SmaeDoubleRangeInput.spec.ts
+++ b/frontend/src/components/camposDeFormulario/SmaeDoubleRangeInput.spec.ts
@@ -1,0 +1,526 @@
+import { mount } from '@vue/test-utils';
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { nextTick, ref } from 'vue';
+import SmaeDoubleRangeInput from './SmaeDoubleRangeInput.vue';
+
+// Mock dos helpers
+vi.mock('@/helpers/dinheiro', () => ({
+  default: vi.fn((valor: number, opcoes?: { style?: string; currency?: string }) => {
+    if (opcoes?.style === 'currency') {
+      return `R$ ${valor.toFixed(2).replace('.', ',')}`;
+    }
+    if (opcoes?.style === 'decimal') {
+      return valor.toFixed(2).replace('.', ',');
+    }
+    return valor.toString();
+  }),
+}));
+
+vi.mock('@/helpers/toFloat', () => ({
+  default: vi.fn((v: string | number) => {
+    if (typeof v === 'number') return v;
+    const str = String(v).replace(/[^0-9\-,]/g, '').replace(',', '.');
+    return parseFloat(str);
+  }),
+}));
+
+// Mock do useField
+const mockSetMin = vi.fn();
+const mockSetMax = vi.fn();
+const mockValorMinRef = ref<number | string | null>(null);
+const mockValorMaxRef = ref<number | string | null>(null);
+
+vi.mock('vee-validate', () => ({
+  useField: vi.fn((name) => {
+    const fieldName = typeof name === 'function' ? name() : name;
+    if (fieldName.includes('min')) {
+      return {
+        value: mockValorMinRef,
+        setValue: mockSetMin,
+      };
+    }
+    return {
+      value: mockValorMaxRef,
+      setValue: mockSetMax,
+    };
+  }),
+}));
+
+describe('SmaeDoubleRangeInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValorMinRef.value = null;
+    mockValorMaxRef.value = null;
+  });
+
+  const montarComponente = (props = {}) => mount(SmaeDoubleRangeInput, {
+    props: {
+      nameMin: 'valor_min',
+      nameMax: 'valor_max',
+      min: 0,
+      max: 100,
+      ...props,
+    },
+  });
+
+  describe('renderização', () => {
+    it('renderiza dois sliders de range', () => {
+      const wrapper = montarComponente();
+
+      const sliders = wrapper.findAll('input[type="range"]');
+      expect(sliders).toHaveLength(2);
+    });
+
+    it('renderiza inputs hidden para submissão de formulário', () => {
+      const wrapper = montarComponente();
+
+      const hiddenInputs = wrapper.findAll('input[type="hidden"]');
+      expect(hiddenInputs).toHaveLength(2);
+      expect(hiddenInputs[0].attributes('name')).toBe('valor_min');
+      expect(hiddenInputs[1].attributes('name')).toBe('valor_max');
+    });
+
+    it('aplica valores min e max aos sliders', async () => {
+      const wrapper = montarComponente({ min: 10, max: 100 });
+
+      await nextTick();
+
+      const vm = wrapper.vm as any;
+
+      // Verificar que os valores estão dentro do range
+      expect(vm.sliderMin).toBeGreaterThanOrEqual(10);
+      expect(vm.sliderMax).toBeLessThanOrEqual(100);
+    });
+
+    it('renderiza labels quando mostrarInputs é false', () => {
+      const wrapper = montarComponente({ mostrarInputs: false });
+
+      expect(wrapper.find('.range-labels').exists()).toBe(true);
+      expect(wrapper.find('.range-inputs').exists()).toBe(false);
+    });
+
+    it('renderiza inputs editáveis quando mostrarInputs é true', () => {
+      const wrapper = montarComponente({ mostrarInputs: true });
+
+      expect(wrapper.find('.range-inputs').exists()).toBe(true);
+      expect(wrapper.find('.range-labels').exists()).toBe(false);
+    });
+
+    it('renderiza prefixo R$ nos inputs quando formatarMoeda é true', () => {
+      const wrapper = montarComponente({ mostrarInputs: true, formatarMoeda: true });
+
+      const prefix = wrapper.find('.input-prefix');
+      expect(prefix.exists()).toBe(true);
+      expect(prefix.text()).toBe('R$');
+    });
+
+    it('não renderiza prefixo R$ quando formatarMoeda é false', () => {
+      const wrapper = montarComponente({ mostrarInputs: true, formatarMoeda: false });
+
+      expect(wrapper.find('.input-prefix').exists()).toBe(false);
+    });
+  });
+
+  describe('props e defaults', () => {
+    it('usa valores padrão quando props não são fornecidas', () => {
+      const wrapper = montarComponente();
+
+      const sliders = wrapper.findAll('input[type="range"]');
+      expect(sliders).toHaveLength(2);
+    });
+
+    it('usa step customizado quando fornecido', () => {
+      const wrapper = montarComponente({ step: 5 });
+
+      const sliders = wrapper.findAll('input[type="range"]');
+      expect(sliders[0].attributes('step')).toBe('5');
+    });
+
+    it('usa step padrão 0.01 quando não fornecido', () => {
+      const wrapper = montarComponente({ step: null });
+
+      const sliders = wrapper.findAll('input[type="range"]');
+      expect(sliders[0].attributes('step')).toBe('0.01');
+    });
+  });
+
+  describe('interação com sliders', () => {
+    it('atualiza valor mínimo ao mover slider mínimo', async () => {
+      const wrapper = montarComponente({ min: 0, max: 100 });
+
+      const sliderMin = wrapper.findAll('input[type="range"]')[0];
+      await sliderMin.setValue(30);
+
+      expect(mockSetMin).toHaveBeenCalledWith(30);
+    });
+
+    it('atualiza valor máximo ao mover slider máximo', async () => {
+      const wrapper = montarComponente({ min: 0, max: 100 });
+
+      const sliderMax = wrapper.findAll('input[type="range"]')[1];
+      await sliderMax.setValue(70);
+
+      expect(mockSetMax).toHaveBeenCalledWith(70);
+    });
+  });
+
+  describe('interação com inputs de texto', () => {
+    it('atualiza slider ao editar input mínimo', async () => {
+      const wrapper = montarComponente({
+        min: 0,
+        max: 1000,
+        mostrarInputs: true,
+      });
+
+      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
+      const inputMin = inputs[0];
+
+      await inputMin.setValue('500');
+      await inputMin.trigger('change');
+
+      expect(mockSetMin).toHaveBeenCalled();
+    });
+
+    it('atualiza slider ao editar input máximo', async () => {
+      const wrapper = montarComponente({
+        min: 0,
+        max: 1000,
+        mostrarInputs: true,
+      });
+
+      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
+      const inputMax = inputs[1];
+
+      await inputMax.setValue('800');
+      await inputMax.trigger('change');
+
+      expect(mockSetMax).toHaveBeenCalled();
+    });
+
+    it('valida valores ao editar inputs', async () => {
+      const wrapper = montarComponente({
+        min: 0,
+        max: 100,
+        mostrarInputs: true,
+      });
+      const vm = wrapper.vm as any;
+
+      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
+      const inputMin = inputs[0];
+
+      // Tentar definir valor acima do máximo
+      await inputMin.setValue('150');
+      await inputMin.trigger('change');
+
+      // Deve ser limitado ao máximo
+      expect(vm.sliderMin).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('acessibilidade', () => {
+    it('slider mínimo tem aria-label básico quando mostrarInputs é false', () => {
+      const wrapper = montarComponente({ mostrarInputs: false });
+
+      const sliderMin = wrapper.findAll('input[type="range"]')[0];
+      expect(sliderMin.attributes('aria-label')).toBe('Valor mínimo');
+    });
+
+    it('slider máximo tem aria-label básico quando mostrarInputs é false', () => {
+      const wrapper = montarComponente({ mostrarInputs: false });
+
+      const sliderMax = wrapper.findAll('input[type="range"]')[1];
+      expect(sliderMax.attributes('aria-label')).toBe('Valor máximo');
+    });
+
+    it('slider mínimo tem aria-label diferenciado quando mostrarInputs é true', () => {
+      const wrapper = montarComponente({ mostrarInputs: true });
+
+      const sliderMin = wrapper.findAll('input[type="range"]')[0];
+      expect(sliderMin.attributes('aria-label')).toBe('Slider valor mínimo');
+    });
+
+    it('slider máximo tem aria-label diferenciado quando mostrarInputs é true', () => {
+      const wrapper = montarComponente({ mostrarInputs: true });
+
+      const sliderMax = wrapper.findAll('input[type="range"]')[1];
+      expect(sliderMax.attributes('aria-label')).toBe('Slider valor máximo');
+    });
+
+    it('inputs de texto têm aria-label quando mostrarInputs é true', () => {
+      const wrapper = montarComponente({ mostrarInputs: true });
+
+      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
+      expect(inputs[0].attributes('aria-label')).toBe('Valor mínimo');
+      expect(inputs[1].attributes('aria-label')).toBe('Valor máximo');
+    });
+
+    it('inputs de texto têm placeholder', () => {
+      const wrapper = montarComponente({ mostrarInputs: true });
+
+      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
+      expect(inputs[0].attributes('placeholder')).toBe('Mínimo');
+      expect(inputs[1].attributes('placeholder')).toBe('Máximo');
+    });
+  });
+
+  describe('formatação', () => {
+    it('formata valores como moeda quando formatarMoeda é true', async () => {
+      const wrapper = montarComponente({
+        min: 0,
+        max: 10000,
+        formatarMoeda: true,
+        mostrarInputs: false,
+      });
+      const vm = wrapper.vm as any;
+
+      vm.sliderMin = 1234.56;
+      await nextTick();
+
+      // Verifica se o helper dinheiro foi chamado
+      const dinheiro = await import('@/helpers/dinheiro');
+      expect(dinheiro.default).toHaveBeenCalled();
+    });
+
+    it('exibe valores numéricos quando formatarMoeda é false', () => {
+      const wrapper = montarComponente({
+        min: 0,
+        max: 100,
+        formatarMoeda: false,
+        mostrarInputs: false,
+      });
+      const vm = wrapper.vm as any;
+
+      const valorFormatado = vm.valorMinFormatado;
+      expect(typeof valorFormatado === 'number' || typeof valorFormatado === 'string').toBe(true);
+    });
+
+    it('inputs de texto têm type="text" quando formatarMoeda é true', () => {
+      const wrapper = montarComponente({
+        mostrarInputs: true,
+        formatarMoeda: true,
+      });
+
+      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
+      expect(inputs[0].attributes('type')).toBe('text');
+    });
+
+    it('inputs de texto têm type="number" quando formatarMoeda é false', () => {
+      const wrapper = montarComponente({
+        mostrarInputs: true,
+        formatarMoeda: false,
+      });
+
+      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
+      expect(inputs[0].attributes('type')).toBe('number');
+    });
+  });
+
+  describe('sincronização com VeeValidate', () => {
+    it('inicializa com valores do VeeValidate quando disponíveis', () => {
+      mockValorMinRef.value = 25;
+      mockValorMaxRef.value = 75;
+
+      const wrapper = montarComponente({ min: 0, max: 100 });
+      const vm = wrapper.vm as any;
+
+      expect(vm.sliderMin).toBe(25);
+      expect(vm.sliderMax).toBe(75);
+    });
+
+    it('usa valores padrão quando VeeValidate retorna null', () => {
+      mockValorMinRef.value = null;
+      mockValorMaxRef.value = null;
+
+      const wrapper = montarComponente({ min: 0, max: 100 });
+      const vm = wrapper.vm as any;
+
+      expect(vm.sliderMin).toBe(0);
+      expect(vm.sliderMax).toBe(100);
+    });
+
+    it('chama setValue do VeeValidate ao inicializar com valores padrão', () => {
+      mockValorMinRef.value = null;
+      mockValorMaxRef.value = null;
+
+      montarComponente({ min: 0, max: 100 });
+
+      expect(mockSetMin).toHaveBeenCalledWith(0);
+      expect(mockSetMax).toHaveBeenCalledWith(100);
+    });
+
+    it('preserva valores do VeeValidate mesmo quando estão fora do range visual', () => {
+      mockValorMinRef.value = 12312315414.18;
+      mockValorMaxRef.value = 12312315414.18;
+
+      const wrapper = montarComponente({ min: 0, max: 10000000 });
+      const vm = wrapper.vm as any;
+
+      // Os valores reais devem ser preservados, não limitados
+      expect(vm.sliderMin).toBe(12312315414.18);
+      expect(vm.sliderMax).toBe(12312315414.18);
+    });
+
+    it('preserva valores negativos do VeeValidate', () => {
+      mockValorMinRef.value = -100;
+      mockValorMaxRef.value = -50;
+
+      const wrapper = montarComponente({ min: 0, max: 100 });
+      const vm = wrapper.vm as any;
+
+      // Valores negativos são válidos e devem ser preservados
+      expect(vm.sliderMin).toBe(-100);
+      expect(vm.sliderMax).toBe(-50);
+    });
+  });
+
+  describe('ciclo de vida', () => {
+    it('atualiza ranges após montagem', async () => {
+      const wrapper = montarComponente({ min: 0, max: 100 });
+      const vm = wrapper.vm as any;
+
+      // onMounted é executado após nextTick
+      await nextTick();
+      await nextTick();
+
+      expect(vm.ready).toBe(true);
+    });
+
+    it('atualiza ranges quando prop min muda', async () => {
+      const wrapper = montarComponente({ min: 0, max: 100 });
+      const vm = wrapper.vm as any;
+
+      await wrapper.setProps({ min: 10 });
+      await nextTick();
+
+      // Verifica que a função de atualização foi chamada (não modifica valores)
+      expect(vm.inputMinRef).toBeTruthy();
+    });
+
+    it('atualiza ranges quando prop max muda', async () => {
+      const wrapper = montarComponente({ min: 0, max: 100 });
+      const vm = wrapper.vm as any;
+
+      await wrapper.setProps({ max: 90 });
+      await nextTick();
+
+      // Verifica que a função de atualização foi chamada (não modifica valores)
+      expect(vm.inputMaxRef).toBeTruthy();
+    });
+  });
+
+  describe('validação de valores', () => {
+    it('mantém valores dentro do range ao atualizar via input', async () => {
+      const wrapper = montarComponente({
+        min: 0,
+        max: 100,
+        mostrarInputs: true,
+      });
+      const vm = wrapper.vm as any;
+
+      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
+      const inputMin = inputs[0];
+
+      // Tentar valor negativo
+      await inputMin.setValue('-50');
+      await inputMin.trigger('change');
+
+      expect(vm.sliderMin).toBeGreaterThanOrEqual(0);
+    });
+
+    it('ignora valores NaN ao atualizar via input', async () => {
+      const wrapper = montarComponente({
+        min: 0,
+        max: 100,
+        mostrarInputs: true,
+      });
+      const vm = wrapper.vm as any;
+
+      const valorAnterior = vm.sliderMin;
+      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
+      const inputMin = inputs[0];
+
+      // Valor inválido
+      await inputMin.setValue('abc');
+      await inputMin.trigger('change');
+
+      // Valor não deve mudar
+      expect(vm.sliderMin).toBe(valorAnterior);
+    });
+  });
+
+  describe('estilização dinâmica', () => {
+    it('aplica variáveis CSS customizadas', () => {
+      const wrapper = montarComponente();
+
+      const rangeWrapper = wrapper.find('.range-wrapper');
+      const style = rangeWrapper.attributes('style');
+
+      expect(style).toContain('--thumb-width');
+      expect(style).toContain('--track-height');
+    });
+
+    it('atualiza gradient-position nos sliders', async () => {
+      const wrapper = montarComponente({ min: 0, max: 100 });
+      const vm = wrapper.vm as any;
+
+      await nextTick();
+
+      // Verificar que os elementos têm referências
+      expect(vm.inputMinRef).toBeTruthy();
+      expect(vm.inputMaxRef).toBeTruthy();
+    });
+  });
+
+  describe('caso especial: min === max', () => {
+    it('marca sliders como readonly quando min === max', () => {
+      const wrapper = montarComponente({ min: 12312315414.18, max: 12312315414.18 });
+
+      const sliders = wrapper.findAll('input[type="range"]');
+      expect(sliders[0].attributes('data-readonly')).toBe('true');
+      expect(sliders[1].attributes('data-readonly')).toBe('true');
+    });
+
+    it('marca inputs de texto como readonly quando min === max', () => {
+      const wrapper = montarComponente({
+        min: 12312315414.18,
+        max: 12312315414.18,
+        mostrarInputs: true,
+      });
+
+      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
+      expect(inputs[0].attributes('readonly')).toBeDefined();
+      expect(inputs[1].attributes('readonly')).toBeDefined();
+    });
+
+    it('define valores iguais quando min === max', () => {
+      mockValorMinRef.value = null;
+      mockValorMaxRef.value = null;
+
+      const wrapper = montarComponente({ min: 1000, max: 1000 });
+      const vm = wrapper.vm as any;
+
+      expect(vm.sliderMin).toBe(1000);
+      expect(vm.sliderMax).toBe(1000);
+    });
+
+    it('isReadonly é true quando min === max', () => {
+      const wrapper = montarComponente({ min: 5000, max: 5000 });
+      const vm = wrapper.vm as any;
+
+      expect(vm.isReadonly).toBe(true);
+    });
+
+    it('isReadonly é false quando min !== max', () => {
+      const wrapper = montarComponente({ min: 0, max: 100 });
+      const vm = wrapper.vm as any;
+
+      expect(vm.isReadonly).toBe(false);
+    });
+  });
+});

--- a/frontend/src/components/camposDeFormulario/SmaeDoubleRangeInput.vue
+++ b/frontend/src/components/camposDeFormulario/SmaeDoubleRangeInput.vue
@@ -1,0 +1,626 @@
+<script setup lang="ts">
+import { useField } from 'vee-validate';
+import {
+  computed, ref, watch, nextTick, onMounted,
+} from 'vue';
+
+import dinheiro from '@/helpers/dinheiro';
+import toFloat from '@/helpers/toFloat';
+
+interface Props {
+  nameMin: string;
+  nameMax: string;
+  min: number;
+  max: number;
+  step?: number | null;
+  formatarMoeda?: boolean;
+  precision?: number;
+  mostrarInputs?: boolean;
+  minSelecionado?: number | null;
+  maxSelecionado?: number | null;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  step: null,
+  formatarMoeda: true,
+  precision: 3,
+  mostrarInputs: false,
+  minSelecionado: null,
+  maxSelecionado: null,
+});
+
+const stepCalculado = computed<number>(() => {
+  if (props.step !== null && props.step !== undefined) {
+    return props.step;
+  }
+  return 0.01;
+});
+
+const { value: valorMin, setValue: setMin } = useField<number | string | null>(() => props.nameMin);
+const { value: valorMax, setValue: setMax } = useField<number | string | null>(() => props.nameMax);
+
+const inputMinRef = ref<HTMLInputElement | null>(null);
+const inputMaxRef = ref<HTMLInputElement | null>(null);
+const ready = ref<boolean>(false);
+
+function obterValorInicialMin(): number {
+  if (valorMin.value !== undefined && valorMin.value !== null && valorMin.value !== '') {
+    return parseFloat(String(valorMin.value));
+  }
+  if (props.minSelecionado !== null && props.minSelecionado !== undefined) {
+    return props.minSelecionado;
+  }
+  return props.min;
+}
+
+function obterValorInicialMax(): number {
+  if (valorMax.value !== undefined && valorMax.value !== null && valorMax.value !== '') {
+    return parseFloat(String(valorMax.value));
+  }
+  if (props.maxSelecionado !== null && props.maxSelecionado !== undefined) {
+    return props.maxSelecionado;
+  }
+  return props.max;
+}
+
+const sliderMin = ref<number>(obterValorInicialMin());
+
+const sliderMax = ref<number>(obterValorInicialMax());
+
+if (valorMin.value === undefined || valorMin.value === null || valorMin.value === '') {
+  setMin(sliderMin.value);
+}
+if (valorMax.value === undefined || valorMax.value === null || valorMax.value === '') {
+  setMax(sliderMax.value);
+}
+
+const thumbWidth = 20;
+const thumbWidthVar = `${thumbWidth}px`;
+
+type RoundingMethod = 'ceil' | 'floor';
+
+function updateRanges(method: RoundingMethod = 'ceil'): void {
+  if (!inputMinRef.value || !inputMaxRef.value) return;
+
+  const { min } = props;
+  const { max } = props;
+  const step = stepCalculado.value;
+  const minValue = sliderMin.value;
+  const maxValue = sliderMax.value;
+
+  const midValue = (maxValue - minValue) / 2;
+  let mid = minValue + Math[method](midValue / step) * step;
+
+  mid = Math.max(minValue, Math.min(maxValue, mid));
+
+  const range = max - min;
+
+  // Quando range é 0 (min === max), cria um range artificial para renderização
+  if (range === 0) {
+    // Cria um range artificial de ±1 ao redor do valor único
+    const artificialMin = min - 1;
+    const artificialMax = max + 1;
+    const artificialMid = min; // O meio é o valor único
+
+    inputMinRef.value.style.flexBasis = `calc(50% + ${thumbWidthVar})`;
+    inputMinRef.value.min = artificialMin.toString();
+    inputMinRef.value.max = artificialMid.toString();
+
+    inputMaxRef.value.style.flexBasis = `calc(50% + ${thumbWidthVar})`;
+    inputMaxRef.value.min = artificialMid.toString();
+    inputMaxRef.value.max = artificialMax.toString();
+
+    // Ambos os thumbs ficam no final de seus ranges (100%)
+    inputMinRef.value.style.setProperty('--gradient-position', `calc(100% + (-0.5 * ${thumbWidthVar}))`);
+    inputMaxRef.value.style.setProperty('--gradient-position', `calc(0% + (0.5 * ${thumbWidthVar}))`);
+    return;
+  }
+
+  // Cálculo normal: divide o range baseado no ponto médio
+  const leftWidthPercent = (((mid - min) / range) * 100).toFixed(props.precision);
+  const rightWidthPercent = (((max - mid) / range) * 100).toFixed(props.precision);
+
+  inputMinRef.value.style.flexBasis = `calc(${leftWidthPercent}% + ${thumbWidthVar})`;
+  inputMinRef.value.min = min.toString();
+  inputMinRef.value.max = mid.toFixed(props.precision);
+
+  inputMaxRef.value.style.flexBasis = `calc(${rightWidthPercent}% + ${thumbWidthVar})`;
+  inputMaxRef.value.min = mid.toFixed(props.precision);
+  inputMaxRef.value.max = max.toString();
+
+  const minRange = mid - min;
+  const maxRange = max - mid;
+
+  const minFill = (minValue - min) / minRange || 0;
+  const maxFill = (maxValue - mid) / maxRange || 0;
+
+  const minFillPercentage = (minFill * 100).toFixed(props.precision);
+  const maxFillPercentage = (maxFill * 100).toFixed(props.precision);
+
+  const minFillThumb = (0.5 - minFill).toFixed(props.precision);
+  const maxFillThumb = (0.5 - maxFill).toFixed(props.precision);
+
+  inputMinRef.value.style.setProperty(
+    '--gradient-position',
+    `calc(${minFillPercentage}% + (${minFillThumb} * ${thumbWidthVar}))`,
+  );
+
+  inputMaxRef.value.style.setProperty(
+    '--gradient-position',
+    `calc(${maxFillPercentage}% + (${maxFillThumb} * ${thumbWidthVar}))`,
+  );
+}
+
+function atualizarMin(event: Event): void {
+  const target = event.target as HTMLInputElement;
+  const novo = parseFloat(target.value);
+  sliderMin.value = novo;
+  setMin(novo);
+  updateRanges('ceil');
+}
+
+function atualizarMax(event: Event): void {
+  const target = event.target as HTMLInputElement;
+  const novo = parseFloat(target.value);
+  sliderMax.value = novo;
+  setMax(novo);
+  updateRanges('floor');
+}
+
+function handleMinFocus(): void {
+  updateRanges('ceil');
+}
+
+function handleMaxFocus(): void {
+  updateRanges('floor');
+}
+
+const inputMinValue = ref<string>('');
+const inputMaxValue = ref<string>('');
+
+function formatarParaInput(valor: number): string {
+  if (props.formatarMoeda) {
+    return dinheiro(valor, { style: 'decimal' });
+  }
+  return valor.toString();
+}
+
+watch(() => props.min, (): void => {
+  updateRanges('ceil');
+});
+
+watch(() => props.max, (): void => {
+  updateRanges('ceil');
+});
+
+watch(() => props.minSelecionado, (novo): void => {
+  if (novo !== null && novo !== undefined) {
+    sliderMin.value = novo;
+    setMin(novo);
+    updateRanges('ceil');
+  }
+});
+
+watch(() => props.maxSelecionado, (novo): void => {
+  if (novo !== null && novo !== undefined) {
+    sliderMax.value = novo;
+    setMax(novo);
+    updateRanges('floor');
+  }
+});
+
+watch(valorMin, (novo: number | string | null | undefined): void => {
+  if (novo !== undefined && novo !== null && novo !== '') {
+    const valor = parseFloat(String(novo));
+    if (valor !== sliderMin.value) {
+      sliderMin.value = Math.max(props.min, Math.min(Math.min(props.max, sliderMax.value), valor));
+      updateRanges('ceil');
+    }
+  }
+});
+
+watch(valorMax, (novo: number | string | null | undefined): void => {
+  if (novo !== undefined && novo !== null && novo !== '') {
+    const valor = parseFloat(String(novo));
+    if (valor !== sliderMax.value) {
+      sliderMax.value = Math.max(Math.max(props.min, sliderMin.value), Math.min(props.max, valor));
+      updateRanges('floor');
+    }
+  }
+});
+
+watch(sliderMin, (valor: number): void => {
+  inputMinValue.value = formatarParaInput(valor);
+});
+
+watch(sliderMax, (valor: number): void => {
+  inputMaxValue.value = formatarParaInput(valor);
+});
+
+onMounted(async (): Promise<void> => {
+  await nextTick();
+
+  if (inputMinRef.value && inputMaxRef.value) {
+    inputMinRef.value.min = props.min.toString();
+    inputMinRef.value.max = props.max.toString();
+    inputMaxRef.value.min = props.min.toString();
+    inputMaxRef.value.max = props.max.toString();
+  }
+  inputMinValue.value = formatarParaInput(sliderMin.value);
+  inputMaxValue.value = formatarParaInput(sliderMax.value);
+
+  updateRanges('ceil');
+  ready.value = true;
+});
+
+function atualizarMinViaInput(event: Event): void {
+  const target = event.target as HTMLInputElement;
+  const valorString = target.value;
+  const valor = toFloat(valorString);
+
+  if (!Number.isNaN(valor)) {
+    sliderMin.value = Math.max(props.min, Math.min(Math.min(props.max, sliderMax.value), valor));
+    setMin(sliderMin.value);
+    updateRanges('ceil');
+    inputMinValue.value = formatarParaInput(sliderMin.value);
+  }
+}
+
+function atualizarMaxViaInput(event: Event): void {
+  const target = event.target as HTMLInputElement;
+  const valorString = target.value;
+  const valor = toFloat(valorString);
+
+  if (!Number.isNaN(valor)) {
+    sliderMax.value = Math.max(Math.max(props.min, sliderMin.value), Math.min(props.max, valor));
+    setMax(sliderMax.value);
+    updateRanges('floor');
+    inputMaxValue.value = formatarParaInput(sliderMax.value);
+  }
+}
+
+const valorMinFormatado = computed<string | number>(() => (
+  props.formatarMoeda
+    ? dinheiro(sliderMin.value, { style: 'currency', currency: 'BRL' })
+    : sliderMin.value
+));
+
+const valorMaxFormatado = computed<string | number>(() => (
+  props.formatarMoeda
+    ? dinheiro(sliderMax.value, { style: 'currency', currency: 'BRL' })
+    : sliderMax.value
+));
+
+const isReadonly = computed<boolean>(() => props.min === props.max);
+</script>
+
+<template>
+  <div class="smae-range-input">
+    <div
+      class="range-wrapper"
+      :style="{ '--thumb-width': thumbWidthVar, '--track-height': '4px' }"
+    >
+      <input
+        ref="inputMinRef"
+        type="range"
+        :step="stepCalculado"
+        :value="sliderMin"
+        :data-ready="ready"
+        :data-readonly="isReadonly"
+        :aria-readonly="isReadonly"
+        class="range-input"
+        :aria-label="mostrarInputs ? 'Slider valor mínimo' : 'Valor mínimo'"
+        @input="atualizarMin"
+        @focus="handleMinFocus"
+        @mousedown="handleMinFocus"
+        @touchstart="handleMinFocus"
+      >
+
+      <input
+        ref="inputMaxRef"
+        type="range"
+        :step="stepCalculado"
+        :value="sliderMax"
+        :data-ready="ready"
+        :data-readonly="isReadonly"
+        :aria-readonly="isReadonly"
+        class="range-input"
+        :aria-label="mostrarInputs ? 'Slider valor máximo' : 'Valor máximo'"
+        @input="atualizarMax"
+        @focus="handleMaxFocus"
+        @mousedown="handleMaxFocus"
+        @touchstart="handleMaxFocus"
+      >
+    </div>
+
+    <div
+      v-if="!mostrarInputs"
+      class="range-labels flex space-between mt1"
+    >
+      <span class="range-label">{{ valorMinFormatado }}</span>
+      <span class="range-label">{{ valorMaxFormatado }}</span>
+    </div>
+
+    <div
+      v-else
+      class="range-inputs flex g2 mt1"
+    >
+      <div class="f1 flex">
+        <span
+          v-if="formatarMoeda"
+          class="input-prefix"
+        >R$</span>
+        <input
+          v-model="inputMinValue"
+          :type="formatarMoeda ? 'text' : 'number'"
+          :min="formatarMoeda ? undefined : min"
+          :max="formatarMoeda ? undefined : max"
+          :step="formatarMoeda ? undefined : stepCalculado"
+          :readonly="isReadonly"
+          :class="['inputtext light', { 'with-prefix': formatarMoeda }]"
+          placeholder="Mínimo"
+          aria-label="Valor mínimo"
+          @change="atualizarMinViaInput"
+          @keyup.enter="atualizarMinViaInput"
+        >
+      </div>
+      <div class="f1 flex">
+        <span
+          v-if="formatarMoeda"
+          class="input-prefix"
+        >R$</span>
+        <input
+          v-model="inputMaxValue"
+          :type="formatarMoeda ? 'text' : 'number'"
+          :min="formatarMoeda ? undefined : min"
+          :max="formatarMoeda ? undefined : max"
+          :readonly="isReadonly"
+          :step="formatarMoeda ? undefined : stepCalculado"
+          :class="['inputtext light', { 'with-prefix': formatarMoeda }]"
+          placeholder="Máximo"
+          aria-label="Valor máximo"
+          @change="atualizarMaxViaInput"
+          @keyup.enter="atualizarMaxViaInput"
+        >
+      </div>
+    </div>
+
+    <input
+      type="hidden"
+      :name="nameMin"
+      :value="sliderMin"
+    >
+    <input
+      type="hidden"
+      :name="nameMax"
+      :value="sliderMax"
+    >
+  </div>
+</template>
+
+<style lang="less" scoped>
+@import '@/_less/variables.less';
+
+.smae-range-input {
+  position: relative;
+  padding: 0.5rem 0;
+}
+
+.range-wrapper {
+  display: flex;
+  height: 1.5rem;
+  max-width: 100%;
+  width: 100%;
+  box-sizing: border-box;
+  // Padding apenas na direita para acomodar os thumbs
+  padding-inline-end: calc(var(--thumb-width) * 2);
+}
+
+.range-input {
+  -webkit-tap-highlight-color: transparent;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: none;
+  border-radius: 0;
+  // Flexbox: começa em 50% + thumb width
+  flex-basis: calc(50% + var(--thumb-width));
+  flex-shrink: 0;
+  font-size: inherit;
+  height: 100%;
+  margin: 0;
+  min-width: var(--thumb-width);
+  outline: none;
+  cursor: pointer;
+  pointer-events: all;
+
+  // === WEBKIT (Chrome, Safari, Edge) ===
+
+  // Track base
+  &::-webkit-slider-runnable-track {
+    background-color: @c200;
+    background-repeat: no-repeat;
+    box-sizing: border-box;
+    height: var(--track-height);
+    cursor: pointer;
+  }
+
+  // Track do input MIN (first-child)
+  &:first-child::-webkit-slider-runnable-track {
+    border-start-start-radius: 1rem;
+    border-end-start-radius: 1rem;
+    // Cinza até gradient-position, depois amarelo
+    background-image: linear-gradient(
+      to right,
+      @c200 var(--gradient-position),
+      @amarelo var(--gradient-position),
+      @amarelo
+    );
+  }
+
+  // Track do input MAX (last-child)
+  &:last-child::-webkit-slider-runnable-track {
+    border-start-end-radius: 1rem;
+    border-end-end-radius: 1rem;
+    // Amarelo até gradient-position, depois cinza
+    background-image: linear-gradient(
+      to right,
+      @amarelo,
+      @amarelo var(--gradient-position),
+      @c200 var(--gradient-position)
+    );
+  }
+
+  // Thumb
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: var(--thumb-width);
+    height: var(--thumb-width);
+    margin-top: calc(var(--track-height) / 2);
+    transform: translateY(-50%);
+    background-color: @amarelo;
+    border-radius: 50%;
+    cursor: grab;
+    border: none;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    transition: all 0.2s ease;
+
+    &:hover {
+      box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
+      transform: translateY(-50%) scale(1.1);
+    }
+
+    &:active {
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+      transform: translateY(-50%) scale(0.95);
+      cursor: grabbing;
+    }
+  }
+
+  // Esconder thumbs até estar pronto
+  &:not([data-ready="true"])::-webkit-slider-thumb {
+    opacity: 0;
+  }
+
+  &:focus-visible::-webkit-slider-thumb {
+    box-shadow: 0 0 0 3px fade(@amarelo, 30%), 0 2px 6px rgba(0, 0, 0, 0.2);
+  }
+
+  // === FIREFOX ===
+
+  // Track base
+  &::-moz-range-track {
+    background-color: @c200;
+    background-repeat: no-repeat;
+    box-sizing: border-box;
+    height: var(--track-height);
+    cursor: pointer;
+  }
+
+  // Track do input MIN (first-child)
+  &:first-child::-moz-range-track {
+    border-start-start-radius: 1rem;
+    border-end-start-radius: 1rem;
+    // Cinza até gradient-position, depois amarelo
+    background-image: linear-gradient(
+      to right,
+      @c200 var(--gradient-position),
+      @amarelo var(--gradient-position),
+      @amarelo
+    );
+  }
+
+  // Track do input MAX (last-child)
+  &:last-child::-moz-range-track {
+    border-start-end-radius: 1rem;
+    border-end-end-radius: 1rem;
+    // Amarelo até gradient-position, depois cinza
+    background-image: linear-gradient(
+      to right,
+      @amarelo,
+      @amarelo var(--gradient-position),
+      @c200 var(--gradient-position)
+    );
+  }
+
+  // Thumb
+  &::-moz-range-thumb {
+    width: var(--thumb-width);
+    height: var(--thumb-width);
+    background-color: @amarelo;
+    border-radius: 50%;
+    cursor: grab;
+    border: none;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    transition: all 0.2s ease;
+    max-width: 99.99%;
+
+    &:hover {
+      box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
+      transform: scale(1.1);
+    }
+
+    &:active {
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+      transform: scale(0.95);
+      cursor: grabbing;
+    }
+  }
+
+  // Esconder thumbs até estar pronto
+  &:not([data-ready="true"])::-moz-range-thumb {
+    opacity: 0;
+  }
+
+  &:focus-visible::-moz-range-thumb {
+    box-shadow: 0 0 0 3px fade(@amarelo, 30%), 0 2px 6px rgba(0, 0, 0, 0.2);
+  }
+
+  // Estado readonly: desabilita interação
+  &[data-readonly="true"] {
+    pointer-events: none;
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+// Focus no wrapper quando qualquer input tiver foco
+.range-wrapper:has(input:focus-visible) {
+  outline: 2px solid fade(@amarelo, 50%);
+  outline-offset: 4px;
+  border-radius: 2px;
+}
+
+.range-labels {
+  user-select: none;
+}
+
+.range-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: @c600;
+}
+
+// Inputs editáveis
+.range-inputs {
+  .input-prefix {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 0.75rem;
+    background-color: @c100;
+    border: 1px solid @c200;
+    border-right: none;
+    border-radius: 4px 0 0 4px;
+    font-weight: 500;
+    color: @c600;
+    font-size: 0.875rem;
+    white-space: nowrap;
+  }
+
+  .with-prefix {
+    border-radius: 0 4px 4px 0;
+    flex: 1;
+  }
+}
+</style>

--- a/frontend/src/components/camposDeFormulario/SmaeRangeInput.md
+++ b/frontend/src/components/camposDeFormulario/SmaeRangeInput.md
@@ -1,401 +1,54 @@
-# Documentação do Componente SmaeRangeInput
+# SmaeRangeInput
 
-## Visão Geral
-
-`SmaeRangeInput` é um componente de entrada dupla de intervalo (dual range slider) que permite aos usuários selecionar valores mínimos e máximos dentro de um range específico. O componente integra-se com VeeValidate para validação de formulários e oferece opções de formatação monetária, inputs de texto editáveis e sincronização bidirecional.
+Slider de valor único com `v-model`. Componente primitivo, sem dependências de formulário.
 
 ## Props
 
-### `nameMin` (obrigatória)
+| Prop         | Tipo               | Padrão | Descrição                                                         |
+| ------------ | ------------------ | ------ | ----------------------------------------------------------------- |
+| `modelValue` | `number`           | —      | **(obrigatória)** Valor atual do slider                           |
+| `min`        | `number \| string` | `0`    | Valor mínimo                                                      |
+| `max`        | `number \| string` | `100`  | Valor máximo                                                      |
+| `step`       | `number \| string` | `1`    | Incremento                                                        |
+| `name`       | `string`           | `''`   | Atributo `name` do input (útil para submit de formulário nativo)  |
 
-- **Tipo:** `string`
-- **Descrição:** Nome do campo para o valor mínimo. Usado pelo VeeValidate para gerenciar o estado do campo.
+## Emits
 
-### `nameMax` (obrigatória)
+| Evento               | Payload  | Descrição                               |
+| -------------------- | -------- | --------------------------------------- |
+| `update:modelValue`  | `number` | Disparado a cada interação com o slider |
 
-- **Tipo:** `string`
-- **Descrição:** Nome do campo para o valor máximo. Usado pelo VeeValidate para gerenciar o estado do campo.
-
-### `min`
-
-- **Tipo:** `number`
-- **Padrão:** `0`
-- **Descrição:** Valor mínimo permitido para o range.
-
-### `max`
-
-- **Tipo:** `number`
-- **Padrão:** `100`
-- **Descrição:** Valor máximo permitido para o range.
-
-### `step`
-
-- **Tipo:** `number | null`
-- **Padrão:** `null`
-- **Descrição:** Incremento dos valores. Se `null`, usa `0.01` como padrão para permitir valores decimais precisos.
-
-### `formatarMoeda`
-
-- **Tipo:** `boolean`
-- **Padrão:** `true`
-- **Descrição:** Quando `true`, formata os valores como moeda brasileira (R$). Quando `false`, exibe valores numéricos simples.
-
-### `precision`
-
-- **Tipo:** `number`
-- **Padrão:** `3`
-- **Descrição:** Número de casas decimais para cálculos internos de posicionamento dos sliders. Não afeta a exibição dos valores.
-
-### `mostrarInputs`
-
-- **Tipo:** `boolean`
-- **Padrão:** `false`
-- **Descrição:** Quando `true`, exibe campos de texto editáveis abaixo dos sliders para entrada manual de valores. Quando `false`, exibe apenas labels formatados.
-
-## Como Usar
-
-### Exemplo Básico
+## Uso básico
 
 ```vue
-<template>
-  <form>
-    <label>Faixa de Preço</label>
-    <SmaeRangeInput
-      name-min="preco_min"
-      name-max="preco_max"
-      :min="0"
-      :max="10000"
-    />
-  </form>
-</template>
-
-<script setup>
-import SmaeRangeInput from '@/components/camposDeFormulario/SmaeRangeInput.vue';
-</script>
+<SmaeRangeInput v-model="nivel" />
 ```
 
-### Exemplo com Inputs Editáveis
+## Com limites e step customizados
 
 ```vue
 <SmaeRangeInput
-  name-min="valor_min"
-  name-max="valor_max"
-  :min="0"
-  :max="100000"
-  :mostrar-inputs="true"
+  v-model="nivel"
+  name="nivel"
+  :min="1"
+  :max="nivelMaximo"
+  :step="1"
 />
-```
-
-Permite que o usuário ajuste os valores tanto pelos sliders quanto digitando diretamente nos campos de texto.
-
-### Exemplo sem Formatação Monetária
-
-```vue
-<SmaeRangeInput
-  name-min="quantidade_min"
-  name-max="quantidade_max"
-  :min="0"
-  :max="1000"
-  :formatar-moeda="false"
-/>
-```
-
-Exibe valores numéricos simples sem o símbolo R$ e formatação de moeda.
-
-### Exemplo com Step Customizado
-
-```vue
-<SmaeRangeInput
-  name-min="peso_min"
-  name-max="peso_max"
-  :min="0"
-  :max="500"
-  :step="0.5"
-  :formatar-moeda="false"
-/>
-```
-
-Define incrementos de 0.5 para ajustes mais precisos.
-
-### Integração com VeeValidate e Yup
-
-```vue
-<template>
-  <Form @submit="onSubmit" :validation-schema="schema">
-    <SmaeRangeInput
-      name-min="valor_min"
-      name-max="valor_max"
-      :min="0"
-      :max="10000"
-      :mostrar-inputs="true"
-    />
-    <button type="submit">Filtrar</button>
-  </Form>
-</template>
-
-<script setup>
-import { Form } from 'vee-validate';
-import * as Yup from 'yup';
-
-const schema = Yup.object({
-  valor_min: Yup.number().min(0).required(),
-  valor_max: Yup.number().max(10000).required(),
-});
-
-function onSubmit(values) {
-  console.log('Valores:', values.valor_min, values.valor_max);
-}
-</script>
-```
-
-### Exemplo com FormularioQueryString
-
-```vue
-<template>
-  <FormularioQueryString
-    v-slot="{ aplicarQueryStrings }"
-    :valores-iniciais="{}"
-  >
-    <form @submit.prevent="aplicarQueryStrings">
-      <SmaeRangeInput
-        name-min="preco_min"
-        name-max="preco_max"
-        :min="0"
-        :max="50000"
-        :mostrar-inputs="true"
-      />
-      <button type="submit">Pesquisar</button>
-    </form>
-  </FormularioQueryString>
-</template>
-```
-
-Os valores dos sliders serão automaticamente incluídos nos query parameters da URL.
-
-## Comportamento
-
-### Sincronização Bidirecional
-
-1. **Sliders → VeeValidate:** Quando o usuário move os sliders, os valores são atualizados no VeeValidate automaticamente
-2. **VeeValidate → Sliders:** Se os valores forem alterados externamente (ex: via `setFieldValue`), os sliders se ajustam
-3. **Inputs de Texto ↔ Sliders:** Quando `mostrarInputs` está ativo, edições nos inputs atualizam os sliders e vice-versa
-
-### Prevenção de Colisão dos Thumbs
-
-O componente usa algoritmo inteligente para evitar que os thumbs (controles deslizantes) se sobreponham:
-
-- Quando o slider mínimo se aproxima do máximo, o ponto médio é calculado usando `Math.ceil`
-- Quando o slider máximo se aproxima do mínimo, o ponto médio é calculado usando `Math.floor`
-- Isso cria uma separação mínima entre os thumbs
-
-### Gradiente de Preenchimento
-
-O componente exibe um gradiente visual que indica o range selecionado:
-
-- Parte cinza clara: valores fora do range selecionado
-- Parte colorida: valores dentro do range selecionado
-- O gradiente é calculado dinamicamente com compensação do tamanho do thumb para precisão visual
-
-### Formatação de Valores
-
-#### Com `formatarMoeda={true}` (padrão):
-
-- **Labels/Inputs:** `R$ 1.234,56` (formato brasileiro)
-- **Inputs editáveis:** Aceita entrada com vírgula como separador decimal
-- **Validação:** Converte automaticamente formato brasileiro para número
-
-#### Com `formatarMoeda={false}`:
-
-- **Labels/Inputs:** `1234.56` (número simples)
-- **Inputs editáveis:** Aceita apenas números e ponto decimal
-
-### Inputs Ocultos para Formulários
-
-O componente sempre renderiza inputs `hidden` com os valores atuais:
-
-```html
-<input type="hidden" name="valor_min" value="1000">
-<input type="hidden" name="valor_max" value="5000">
-```
-
-Isso garante que os valores sejam submetidos com o formulário, mesmo quando os sliders não estão visíveis.
-
-## Acessibilidade
-
-### Labels ARIA
-
-O componente usa labels ARIA contextuais para melhor experiência com leitores de tela:
-
-#### Quando `mostrarInputs={false}`:
-- Slider mínimo: `aria-label="Valor mínimo"`
-- Slider máximo: `aria-label="Valor máximo"`
-
-#### Quando `mostrarInputs={true}`:
-- Slider mínimo: `aria-label="Slider valor mínimo"`
-- Slider máximo: `aria-label="Slider valor máximo"`
-- Input mínimo: `aria-label="Valor mínimo"`
-- Input máximo: `aria-label="Valor máximo"`
-
-A diferenciação evita confusão quando múltiplos controles estão visíveis simultaneamente.
-
-### Navegação por Teclado
-
-- **Setas ←/→:** Ajusta o valor do slider em foco pelo `step` definido
-- **Setas ↑/↓:** Ajusta o valor do slider em foco pelo `step` definido
-- **PageUp/PageDown:** Ajusta o valor em incrementos maiores (10× `step`)
-- **Home:** Define o valor como `min`
-- **End:** Define o valor como `max`
-- **Tab:** Move o foco entre controles
-
-## Integração com Helpers
-
-### Helper `dinheiro`
-
-Usado para formatação de valores monetários:
-
-```javascript
-import dinheiro from '@/helpers/dinheiro';
-
-// Formatação para exibição
-dinheiro(1234.56, { style: 'currency', currency: 'BRL' });
-// Retorna: "R$ 1.234,56"
-
-// Formatação para inputs editáveis
-dinheiro(1234.56, { style: 'decimal' });
-// Retorna: "1.234,56"
-```
-
-### Helper `toFloat`
-
-Usado para converter strings para números, suportando formato brasileiro:
-
-```javascript
-import toFloat from '@/helpers/toFloat';
-
-toFloat('1.234,56'); // 1234.56
-toFloat('1234.56');  // 1234.56
-toFloat('R$ 1.234,56'); // 1234.56
 ```
 
 ## Estilização
 
-O componente usa variáveis CSS customizadas para estilização dinâmica:
+O componente expõe duas variáveis CSS que podem ser sobrescritas pelo pai:
 
 ```css
-.smae-range-input {
-  --thumb-width: 20px;
-  --track-height: 4px;
-  --gradient-position: calc(50% + (0 * var(--thumb-width)));
-}
+--inputrange-thumb-size: 20px;  /* tamanho do thumb circular */
+--inputrange-track-height: 4px; /* altura da trilha */
 ```
 
-### Classes Disponíveis
+O preenchimento colorido da trilha é controlado internamente via `--inputrange-fill`, calculado automaticamente a partir de `modelValue`, `min` e `max`.
 
-- `.smae-range-input`: Container principal
-- `.range-wrapper`: Wrapper dos sliders com flexbox
-- `.range-input`: Input range individual
-- `.range-labels`: Container para labels quando `mostrarInputs={false}`
-- `.range-inputs`: Container para inputs editáveis quando `mostrarInputs={true}`
-- `.input-prefix`: Prefixo "R$" nos inputs editáveis
+## Comportamento especial
 
-## Notas Técnicas
-
-### Precisão Decimal
-
-- O componente usa `step={0.01}` por padrão para suportar valores monetários com centavos
-- Para evitar problemas de arredondamento com ponto flutuante, todos os cálculos internos usam a `precision` configurável
-- Valores são sempre arredondados para o `step` mais próximo
-
-### Flexbox Layout
-
-O componente usa flexbox ao invés de `position: absolute` para posicionamento dos sliders:
-
-```css
-.range-input:first-child {
-  flex-basis: calc(50% + var(--thumb-width));
-}
-
-.range-input:last-child {
-  flex-basis: calc(50% + var(--thumb-width));
-}
-```
-
-Isso garante:
-- Layout responsivo sem cálculos JavaScript complexos
-- Melhor performance de renderização
-- Menos bugs de posicionamento
-
-### Z-Index Dinâmico
-
-O slider em foco recebe `z-index: 2` para aparecer acima do outro, facilitando interações em ranges pequenos.
-
-## Limitações Conhecidas
-
-### Navegadores Antigos
-
-- Requer suporte a `<input type="range">` (IE 10+)
-- Usa CSS Grid e Flexbox (IE 11+ com prefixos)
-- Usa `Math.min/Math.max` extensivamente
-
-### Safari
-
-- A estilização de `<input type="range">` pode ter pequenas diferenças visuais
-- Thumbs podem ter tamanho ligeiramente diferente
-
-### Performance
-
-- Em ranges muito grandes (ex: `min=0, max=1000000`), a sensibilidade do slider pode ser reduzida
-- Recomenda-se usar `step` apropriado para a escala dos valores
-
-## Exemplos de Casos de Uso
-
-### Filtro de Preços em E-commerce
-
-```vue
-<SmaeRangeInput
-  name-min="preco_min"
-  name-max="preco_max"
-  :min="0"
-  :max="10000"
-  :mostrar-inputs="true"
-/>
-```
-
-### Filtro de Área (m²) em Imóveis
-
-```vue
-<SmaeRangeInput
-  name-min="area_min"
-  name-max="area_max"
-  :min="20"
-  :max="500"
-  :step="5"
-  :formatar-moeda="false"
-/>
-```
-
-### Filtro de Salário em Vagas
-
-```vue
-<SmaeRangeInput
-  name-min="salario_min"
-  name-max="salario_max"
-  :min="1320"
-  :max="50000"
-  :step="100"
-/>
-```
-
-### Filtro de Quantidade de Produtos
-
-```vue
-<SmaeRangeInput
-  name-min="qtd_min"
-  name-max="qtd_max"
-  :min="1"
-  :max="100"
-  :step="1"
-  :formatar-moeda="false"
-  :mostrar-inputs="true"
-/>
-```
+- Quando `max <= min`, o fill é fixado em `100%`.
+- O valor emitido é sempre do tipo `number`, independentemente do tipo das props `min`/`max`/`step`.
+- Suporta o estado `disabled` via atributo nativo: o thumb fica opaco e não interativo.

--- a/frontend/src/components/camposDeFormulario/SmaeRangeInput.spec.ts
+++ b/frontend/src/components/camposDeFormulario/SmaeRangeInput.spec.ts
@@ -1,526 +1,141 @@
 import { mount } from '@vue/test-utils';
 import {
-  beforeEach,
+  afterEach,
   describe,
   expect,
   it,
   vi,
 } from 'vitest';
-import { nextTick, ref } from 'vue';
 import SmaeRangeInput from './SmaeRangeInput.vue';
 
-// Mock dos helpers
-vi.mock('@/helpers/dinheiro', () => ({
-  default: vi.fn((valor: number, opcoes?: { style?: string; currency?: string }) => {
-    if (opcoes?.style === 'currency') {
-      return `R$ ${valor.toFixed(2).replace('.', ',')}`;
-    }
-    if (opcoes?.style === 'decimal') {
-      return valor.toFixed(2).replace('.', ',');
-    }
-    return valor.toString();
-  }),
-}));
-
-vi.mock('@/helpers/toFloat', () => ({
-  default: vi.fn((v: string | number) => {
-    if (typeof v === 'number') return v;
-    const str = String(v).replace(/[^0-9\-,]/g, '').replace(',', '.');
-    return parseFloat(str);
-  }),
-}));
-
-// Mock do useField
-const mockSetMin = vi.fn();
-const mockSetMax = vi.fn();
-const mockValorMinRef = ref<number | string | null>(null);
-const mockValorMaxRef = ref<number | string | null>(null);
-
-vi.mock('vee-validate', () => ({
-  useField: vi.fn((name) => {
-    const fieldName = typeof name === 'function' ? name() : name;
-    if (fieldName.includes('min')) {
-      return {
-        value: mockValorMinRef,
-        setValue: mockSetMin,
-      };
-    }
-    return {
-      value: mockValorMaxRef,
-      setValue: mockSetMax,
-    };
-  }),
-}));
-
-describe('SmaeRangeInput', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockValorMinRef.value = null;
-    mockValorMaxRef.value = null;
-  });
-
-  const montarComponente = (props = {}) => mount(SmaeRangeInput, {
+function montar(props = {}) {
+  return mount(SmaeRangeInput, {
     props: {
-      nameMin: 'valor_min',
-      nameMax: 'valor_max',
-      min: 0,
-      max: 100,
+      modelValue: 50,
       ...props,
     },
   });
+}
+
+describe('SmaeRangeInput', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
 
   describe('renderização', () => {
-    it('renderiza dois sliders de range', () => {
-      const wrapper = montarComponente();
-
-      const sliders = wrapper.findAll('input[type="range"]');
-      expect(sliders).toHaveLength(2);
+    it('renderiza um input[type="range"]', () => {
+      const wrapper = montar();
+      expect(wrapper.find('input[type="range"]').exists()).toBe(true);
     });
 
-    it('renderiza inputs hidden para submissão de formulário', () => {
-      const wrapper = montarComponente();
-
-      const hiddenInputs = wrapper.findAll('input[type="hidden"]');
-      expect(hiddenInputs).toHaveLength(2);
-      expect(hiddenInputs[0].attributes('name')).toBe('valor_min');
-      expect(hiddenInputs[1].attributes('name')).toBe('valor_max');
+    it('aplica o valor atual via atributo value', () => {
+      const wrapper = montar({ modelValue: 30 });
+      expect(wrapper.find('input').attributes('value')).toBe('30');
     });
 
-    it('aplica valores min e max aos sliders', async () => {
-      const wrapper = montarComponente({ min: 10, max: 100 });
-
-      await nextTick();
-
-      const vm = wrapper.vm as any;
-
-      // Verificar que os valores estão dentro do range
-      expect(vm.sliderMin).toBeGreaterThanOrEqual(10);
-      expect(vm.sliderMax).toBeLessThanOrEqual(100);
+    it('aplica os atributos min, max e step', () => {
+      const wrapper = montar({ min: 10, max: 200, step: 5 });
+      const input = wrapper.find('input');
+      expect(input.attributes('min')).toBe('10');
+      expect(input.attributes('max')).toBe('200');
+      expect(input.attributes('step')).toBe('5');
     });
 
-    it('renderiza labels quando mostrarInputs é false', () => {
-      const wrapper = montarComponente({ mostrarInputs: false });
-
-      expect(wrapper.find('.range-labels').exists()).toBe(true);
-      expect(wrapper.find('.range-inputs').exists()).toBe(false);
+    it('aplica o atributo name quando fornecido', () => {
+      const wrapper = montar({ name: 'nivel' });
+      expect(wrapper.find('input').attributes('name')).toBe('nivel');
     });
 
-    it('renderiza inputs editáveis quando mostrarInputs é true', () => {
-      const wrapper = montarComponente({ mostrarInputs: true });
-
-      expect(wrapper.find('.range-inputs').exists()).toBe(true);
-      expect(wrapper.find('.range-labels').exists()).toBe(false);
-    });
-
-    it('renderiza prefixo R$ nos inputs quando formatarMoeda é true', () => {
-      const wrapper = montarComponente({ mostrarInputs: true, formatarMoeda: true });
-
-      const prefix = wrapper.find('.input-prefix');
-      expect(prefix.exists()).toBe(true);
-      expect(prefix.text()).toBe('R$');
-    });
-
-    it('não renderiza prefixo R$ quando formatarMoeda é false', () => {
-      const wrapper = montarComponente({ mostrarInputs: true, formatarMoeda: false });
-
-      expect(wrapper.find('.input-prefix').exists()).toBe(false);
+    it('usa defaults: min=0, max=100, step=1, name=""', () => {
+      const wrapper = montar({ modelValue: 0 });
+      const input = wrapper.find('input');
+      expect(input.attributes('min')).toBe('0');
+      expect(input.attributes('max')).toBe('100');
+      expect(input.attributes('step')).toBe('1');
+      expect(input.attributes('name')).toBe('');
     });
   });
 
-  describe('props e defaults', () => {
-    it('usa valores padrão quando props não são fornecidas', () => {
-      const wrapper = montarComponente();
-
-      const sliders = wrapper.findAll('input[type="range"]');
-      expect(sliders).toHaveLength(2);
+  describe('fill (CSS --inputrange-fill)', () => {
+    it('calcula fill corretamente para valor no meio do range', () => {
+      const wrapper = montar({ modelValue: 50, min: 0, max: 100 });
+      const style = wrapper.find('input').attributes('style');
+      expect(style).toContain('--inputrange-fill: 50%');
     });
 
-    it('usa step customizado quando fornecido', () => {
-      const wrapper = montarComponente({ step: 5 });
-
-      const sliders = wrapper.findAll('input[type="range"]');
-      expect(sliders[0].attributes('step')).toBe('5');
+    it('calcula fill 0% quando modelValue === min', () => {
+      const wrapper = montar({ modelValue: 0, min: 0, max: 100 });
+      const style = wrapper.find('input').attributes('style');
+      expect(style).toContain('--inputrange-fill: 0%');
     });
 
-    it('usa step padrão 0.01 quando não fornecido', () => {
-      const wrapper = montarComponente({ step: null });
-
-      const sliders = wrapper.findAll('input[type="range"]');
-      expect(sliders[0].attributes('step')).toBe('0.01');
-    });
-  });
-
-  describe('interação com sliders', () => {
-    it('atualiza valor mínimo ao mover slider mínimo', async () => {
-      const wrapper = montarComponente({ min: 0, max: 100 });
-
-      const sliderMin = wrapper.findAll('input[type="range"]')[0];
-      await sliderMin.setValue(30);
-
-      expect(mockSetMin).toHaveBeenCalledWith(30);
+    it('calcula fill 100% quando modelValue === max', () => {
+      const wrapper = montar({ modelValue: 100, min: 0, max: 100 });
+      const style = wrapper.find('input').attributes('style');
+      expect(style).toContain('--inputrange-fill: 100%');
     });
 
-    it('atualiza valor máximo ao mover slider máximo', async () => {
-      const wrapper = montarComponente({ min: 0, max: 100 });
-
-      const sliderMax = wrapper.findAll('input[type="range"]')[1];
-      await sliderMax.setValue(70);
-
-      expect(mockSetMax).toHaveBeenCalledWith(70);
-    });
-  });
-
-  describe('interação com inputs de texto', () => {
-    it('atualiza slider ao editar input mínimo', async () => {
-      const wrapper = montarComponente({
-        min: 0,
-        max: 1000,
-        mostrarInputs: true,
-      });
-
-      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
-      const inputMin = inputs[0];
-
-      await inputMin.setValue('500');
-      await inputMin.trigger('change');
-
-      expect(mockSetMin).toHaveBeenCalled();
+    it('retorna 100% quando max <= min', () => {
+      const wrapper = montar({ modelValue: 5, min: 10, max: 5 });
+      const style = wrapper.find('input').attributes('style');
+      expect(style).toContain('--inputrange-fill: 100%');
     });
 
-    it('atualiza slider ao editar input máximo', async () => {
-      const wrapper = montarComponente({
-        min: 0,
-        max: 1000,
-        mostrarInputs: true,
-      });
-
-      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
-      const inputMax = inputs[1];
-
-      await inputMax.setValue('800');
-      await inputMax.trigger('change');
-
-      expect(mockSetMax).toHaveBeenCalled();
+    it('retorna 100% quando min === max', () => {
+      const wrapper = montar({ modelValue: 50, min: 50, max: 50 });
+      const style = wrapper.find('input').attributes('style');
+      expect(style).toContain('--inputrange-fill: 100%');
     });
 
-    it('valida valores ao editar inputs', async () => {
-      const wrapper = montarComponente({
-        min: 0,
-        max: 100,
-        mostrarInputs: true,
-      });
-      const vm = wrapper.vm as any;
+    it('aceita min e max como strings', () => {
+      const wrapper = montar({ modelValue: 5, min: '0', max: '10' });
+      const style = wrapper.find('input').attributes('style');
+      expect(style).toContain('--inputrange-fill: 50%');
+    });
 
-      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
-      const inputMin = inputs[0];
+    it('atualiza fill reativamente quando modelValue muda', async () => {
+      const wrapper = montar({ modelValue: 0, min: 0, max: 100 });
+      expect(wrapper.find('input').attributes('style')).toContain('--inputrange-fill: 0%');
 
-      // Tentar definir valor acima do máximo
-      await inputMin.setValue('150');
-      await inputMin.trigger('change');
-
-      // Deve ser limitado ao máximo
-      expect(vm.sliderMin).toBeLessThanOrEqual(100);
+      await wrapper.setProps({ modelValue: 75 });
+      expect(wrapper.find('input').attributes('style')).toContain('--inputrange-fill: 75%');
     });
   });
 
-  describe('acessibilidade', () => {
-    it('slider mínimo tem aria-label básico quando mostrarInputs é false', () => {
-      const wrapper = montarComponente({ mostrarInputs: false });
+  describe('emits', () => {
+    it('emite update:modelValue com número ao interagir com o slider', async () => {
+      const wrapper = montar({ modelValue: 0 });
+      await wrapper.find('input').setValue(42);
 
-      const sliderMin = wrapper.findAll('input[type="range"]')[0];
-      expect(sliderMin.attributes('aria-label')).toBe('Valor mínimo');
+      expect(wrapper.emitted('update:modelValue')).toHaveLength(1);
+      expect(wrapper.emitted('update:modelValue')![0][0]).toBe(42);
     });
 
-    it('slider máximo tem aria-label básico quando mostrarInputs é false', () => {
-      const wrapper = montarComponente({ mostrarInputs: false });
+    it('o valor emitido é sempre do tipo number', async () => {
+      const wrapper = montar({ modelValue: 0 });
+      await wrapper.find('input').setValue('75');
 
-      const sliderMax = wrapper.findAll('input[type="range"]')[1];
-      expect(sliderMax.attributes('aria-label')).toBe('Valor máximo');
-    });
-
-    it('slider mínimo tem aria-label diferenciado quando mostrarInputs é true', () => {
-      const wrapper = montarComponente({ mostrarInputs: true });
-
-      const sliderMin = wrapper.findAll('input[type="range"]')[0];
-      expect(sliderMin.attributes('aria-label')).toBe('Slider valor mínimo');
-    });
-
-    it('slider máximo tem aria-label diferenciado quando mostrarInputs é true', () => {
-      const wrapper = montarComponente({ mostrarInputs: true });
-
-      const sliderMax = wrapper.findAll('input[type="range"]')[1];
-      expect(sliderMax.attributes('aria-label')).toBe('Slider valor máximo');
-    });
-
-    it('inputs de texto têm aria-label quando mostrarInputs é true', () => {
-      const wrapper = montarComponente({ mostrarInputs: true });
-
-      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
-      expect(inputs[0].attributes('aria-label')).toBe('Valor mínimo');
-      expect(inputs[1].attributes('aria-label')).toBe('Valor máximo');
-    });
-
-    it('inputs de texto têm placeholder', () => {
-      const wrapper = montarComponente({ mostrarInputs: true });
-
-      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
-      expect(inputs[0].attributes('placeholder')).toBe('Mínimo');
-      expect(inputs[1].attributes('placeholder')).toBe('Máximo');
+      const emitted = wrapper.emitted('update:modelValue')![0][0];
+      expect(typeof emitted).toBe('number');
+      expect(emitted).toBe(75);
     });
   });
 
-  describe('formatação', () => {
-    it('formata valores como moeda quando formatarMoeda é true', async () => {
-      const wrapper = montarComponente({
-        min: 0,
-        max: 10000,
-        formatarMoeda: true,
-        mostrarInputs: false,
-      });
-      const vm = wrapper.vm as any;
-
-      vm.sliderMin = 1234.56;
-      await nextTick();
-
-      // Verifica se o helper dinheiro foi chamado
-      const dinheiro = await import('@/helpers/dinheiro');
-      expect(dinheiro.default).toHaveBeenCalled();
+  describe('reatividade de props', () => {
+    it('atualiza o atributo value quando modelValue muda', async () => {
+      const wrapper = montar({ modelValue: 10 });
+      await wrapper.setProps({ modelValue: 80 });
+      expect(wrapper.find('input').attributes('value')).toBe('80');
     });
 
-    it('exibe valores numéricos quando formatarMoeda é false', () => {
-      const wrapper = montarComponente({
-        min: 0,
-        max: 100,
-        formatarMoeda: false,
-        mostrarInputs: false,
-      });
-      const vm = wrapper.vm as any;
+    it('atualiza min e max reativamente', async () => {
+      const wrapper = montar({ modelValue: 50, min: 0, max: 100 });
+      await wrapper.setProps({ min: 20, max: 200 });
 
-      const valorFormatado = vm.valorMinFormatado;
-      expect(typeof valorFormatado === 'number' || typeof valorFormatado === 'string').toBe(true);
-    });
-
-    it('inputs de texto têm type="text" quando formatarMoeda é true', () => {
-      const wrapper = montarComponente({
-        mostrarInputs: true,
-        formatarMoeda: true,
-      });
-
-      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
-      expect(inputs[0].attributes('type')).toBe('text');
-    });
-
-    it('inputs de texto têm type="number" quando formatarMoeda é false', () => {
-      const wrapper = montarComponente({
-        mostrarInputs: true,
-        formatarMoeda: false,
-      });
-
-      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
-      expect(inputs[0].attributes('type')).toBe('number');
-    });
-  });
-
-  describe('sincronização com VeeValidate', () => {
-    it('inicializa com valores do VeeValidate quando disponíveis', () => {
-      mockValorMinRef.value = 25;
-      mockValorMaxRef.value = 75;
-
-      const wrapper = montarComponente({ min: 0, max: 100 });
-      const vm = wrapper.vm as any;
-
-      expect(vm.sliderMin).toBe(25);
-      expect(vm.sliderMax).toBe(75);
-    });
-
-    it('usa valores padrão quando VeeValidate retorna null', () => {
-      mockValorMinRef.value = null;
-      mockValorMaxRef.value = null;
-
-      const wrapper = montarComponente({ min: 0, max: 100 });
-      const vm = wrapper.vm as any;
-
-      expect(vm.sliderMin).toBe(0);
-      expect(vm.sliderMax).toBe(100);
-    });
-
-    it('chama setValue do VeeValidate ao inicializar com valores padrão', () => {
-      mockValorMinRef.value = null;
-      mockValorMaxRef.value = null;
-
-      montarComponente({ min: 0, max: 100 });
-
-      expect(mockSetMin).toHaveBeenCalledWith(0);
-      expect(mockSetMax).toHaveBeenCalledWith(100);
-    });
-
-    it('preserva valores do VeeValidate mesmo quando estão fora do range visual', () => {
-      mockValorMinRef.value = 12312315414.18;
-      mockValorMaxRef.value = 12312315414.18;
-
-      const wrapper = montarComponente({ min: 0, max: 10000000 });
-      const vm = wrapper.vm as any;
-
-      // Os valores reais devem ser preservados, não limitados
-      expect(vm.sliderMin).toBe(12312315414.18);
-      expect(vm.sliderMax).toBe(12312315414.18);
-    });
-
-    it('preserva valores negativos do VeeValidate', () => {
-      mockValorMinRef.value = -100;
-      mockValorMaxRef.value = -50;
-
-      const wrapper = montarComponente({ min: 0, max: 100 });
-      const vm = wrapper.vm as any;
-
-      // Valores negativos são válidos e devem ser preservados
-      expect(vm.sliderMin).toBe(-100);
-      expect(vm.sliderMax).toBe(-50);
-    });
-  });
-
-  describe('ciclo de vida', () => {
-    it('atualiza ranges após montagem', async () => {
-      const wrapper = montarComponente({ min: 0, max: 100 });
-      const vm = wrapper.vm as any;
-
-      // onMounted é executado após nextTick
-      await nextTick();
-      await nextTick();
-
-      expect(vm.ready).toBe(true);
-    });
-
-    it('atualiza ranges quando prop min muda', async () => {
-      const wrapper = montarComponente({ min: 0, max: 100 });
-      const vm = wrapper.vm as any;
-
-      await wrapper.setProps({ min: 10 });
-      await nextTick();
-
-      // Verifica que a função de atualização foi chamada (não modifica valores)
-      expect(vm.inputMinRef).toBeTruthy();
-    });
-
-    it('atualiza ranges quando prop max muda', async () => {
-      const wrapper = montarComponente({ min: 0, max: 100 });
-      const vm = wrapper.vm as any;
-
-      await wrapper.setProps({ max: 90 });
-      await nextTick();
-
-      // Verifica que a função de atualização foi chamada (não modifica valores)
-      expect(vm.inputMaxRef).toBeTruthy();
-    });
-  });
-
-  describe('validação de valores', () => {
-    it('mantém valores dentro do range ao atualizar via input', async () => {
-      const wrapper = montarComponente({
-        min: 0,
-        max: 100,
-        mostrarInputs: true,
-      });
-      const vm = wrapper.vm as any;
-
-      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
-      const inputMin = inputs[0];
-
-      // Tentar valor negativo
-      await inputMin.setValue('-50');
-      await inputMin.trigger('change');
-
-      expect(vm.sliderMin).toBeGreaterThanOrEqual(0);
-    });
-
-    it('ignora valores NaN ao atualizar via input', async () => {
-      const wrapper = montarComponente({
-        min: 0,
-        max: 100,
-        mostrarInputs: true,
-      });
-      const vm = wrapper.vm as any;
-
-      const valorAnterior = vm.sliderMin;
-      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
-      const inputMin = inputs[0];
-
-      // Valor inválido
-      await inputMin.setValue('abc');
-      await inputMin.trigger('change');
-
-      // Valor não deve mudar
-      expect(vm.sliderMin).toBe(valorAnterior);
-    });
-  });
-
-  describe('estilização dinâmica', () => {
-    it('aplica variáveis CSS customizadas', () => {
-      const wrapper = montarComponente();
-
-      const rangeWrapper = wrapper.find('.range-wrapper');
-      const style = rangeWrapper.attributes('style');
-
-      expect(style).toContain('--thumb-width');
-      expect(style).toContain('--track-height');
-    });
-
-    it('atualiza gradient-position nos sliders', async () => {
-      const wrapper = montarComponente({ min: 0, max: 100 });
-      const vm = wrapper.vm as any;
-
-      await nextTick();
-
-      // Verificar que os elementos têm referências
-      expect(vm.inputMinRef).toBeTruthy();
-      expect(vm.inputMaxRef).toBeTruthy();
-    });
-  });
-
-  describe('caso especial: min === max', () => {
-    it('marca sliders como readonly quando min === max', () => {
-      const wrapper = montarComponente({ min: 12312315414.18, max: 12312315414.18 });
-
-      const sliders = wrapper.findAll('input[type="range"]');
-      expect(sliders[0].attributes('data-readonly')).toBe('true');
-      expect(sliders[1].attributes('data-readonly')).toBe('true');
-    });
-
-    it('marca inputs de texto como readonly quando min === max', () => {
-      const wrapper = montarComponente({
-        min: 12312315414.18,
-        max: 12312315414.18,
-        mostrarInputs: true,
-      });
-
-      const inputs = wrapper.findAll('.range-inputs input:not([type="hidden"])');
-      expect(inputs[0].attributes('readonly')).toBeDefined();
-      expect(inputs[1].attributes('readonly')).toBeDefined();
-    });
-
-    it('define valores iguais quando min === max', () => {
-      mockValorMinRef.value = null;
-      mockValorMaxRef.value = null;
-
-      const wrapper = montarComponente({ min: 1000, max: 1000 });
-      const vm = wrapper.vm as any;
-
-      expect(vm.sliderMin).toBe(1000);
-      expect(vm.sliderMax).toBe(1000);
-    });
-
-    it('isReadonly é true quando min === max', () => {
-      const wrapper = montarComponente({ min: 5000, max: 5000 });
-      const vm = wrapper.vm as any;
-
-      expect(vm.isReadonly).toBe(true);
-    });
-
-    it('isReadonly é false quando min !== max', () => {
-      const wrapper = montarComponente({ min: 0, max: 100 });
-      const vm = wrapper.vm as any;
-
-      expect(vm.isReadonly).toBe(false);
+      const input = wrapper.find('input');
+      expect(input.attributes('min')).toBe('20');
+      expect(input.attributes('max')).toBe('200');
     });
   });
 });

--- a/frontend/src/components/camposDeFormulario/SmaeRangeInput.vue
+++ b/frontend/src/components/camposDeFormulario/SmaeRangeInput.vue
@@ -1,483 +1,102 @@
 <script setup lang="ts">
-import { useField } from 'vee-validate';
-import {
-  computed, ref, watch, nextTick, onMounted,
-} from 'vue';
-
-import dinheiro from '@/helpers/dinheiro';
-import toFloat from '@/helpers/toFloat';
+import { computed } from 'vue';
 
 interface Props {
-  nameMin: string;
-  nameMax: string;
-  min: number;
-  max: number;
-  step?: number | null;
-  formatarMoeda?: boolean;
-  precision?: number;
-  mostrarInputs?: boolean;
-  minSelecionado?: number | null;
-  maxSelecionado?: number | null;
+  modelValue: number;
+  min?: number | string;
+  max?: number | string;
+  step?: number | string;
+  name?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  step: null,
-  formatarMoeda: true,
-  precision: 3,
-  mostrarInputs: false,
-  minSelecionado: null,
-  maxSelecionado: null,
+  min: 0,
+  max: 100,
+  step: 1,
+  name: '',
 });
 
-const stepCalculado = computed<number>(() => {
-  if (props.step !== null && props.step !== undefined) {
-    return props.step;
-  }
-  return 0.01;
+const emit = defineEmits<{
+  'update:modelValue': [value: number];
+}>();
+
+const fill = computed(() => {
+  const min = Number(props.min);
+  const max = Number(props.max);
+  if (max <= min) return '100%';
+  return `${((props.modelValue - min) / (max - min)) * 100}%`;
 });
 
-const { value: valorMin, setValue: setMin } = useField<number | string | null>(() => props.nameMin);
-const { value: valorMax, setValue: setMax } = useField<number | string | null>(() => props.nameMax);
-
-const inputMinRef = ref<HTMLInputElement | null>(null);
-const inputMaxRef = ref<HTMLInputElement | null>(null);
-const ready = ref<boolean>(false);
-
-function obterValorInicialMin(): number {
-  if (valorMin.value !== undefined && valorMin.value !== null && valorMin.value !== '') {
-    return parseFloat(String(valorMin.value));
-  }
-  if (props.minSelecionado !== null && props.minSelecionado !== undefined) {
-    return props.minSelecionado;
-  }
-  return props.min;
-}
-
-function obterValorInicialMax(): number {
-  if (valorMax.value !== undefined && valorMax.value !== null && valorMax.value !== '') {
-    return parseFloat(String(valorMax.value));
-  }
-  if (props.maxSelecionado !== null && props.maxSelecionado !== undefined) {
-    return props.maxSelecionado;
-  }
-  return props.max;
-}
-
-const sliderMin = ref<number>(obterValorInicialMin());
-
-const sliderMax = ref<number>(obterValorInicialMax());
-
-if (valorMin.value === undefined || valorMin.value === null || valorMin.value === '') {
-  setMin(sliderMin.value);
-}
-if (valorMax.value === undefined || valorMax.value === null || valorMax.value === '') {
-  setMax(sliderMax.value);
-}
-
-const thumbWidth = 20;
-const thumbWidthVar = `${thumbWidth}px`;
-
-type RoundingMethod = 'ceil' | 'floor';
-
-function updateRanges(method: RoundingMethod = 'ceil'): void {
-  if (!inputMinRef.value || !inputMaxRef.value) return;
-
-  const { min } = props;
-  const { max } = props;
-  const step = stepCalculado.value;
-  const minValue = sliderMin.value;
-  const maxValue = sliderMax.value;
-
-  const midValue = (maxValue - minValue) / 2;
-  let mid = minValue + Math[method](midValue / step) * step;
-
-  mid = Math.max(minValue, Math.min(maxValue, mid));
-
-  const range = max - min;
-
-  // Quando range é 0 (min === max), cria um range artificial para renderização
-  if (range === 0) {
-    // Cria um range artificial de ±1 ao redor do valor único
-    const artificialMin = min - 1;
-    const artificialMax = max + 1;
-    const artificialMid = min; // O meio é o valor único
-
-    inputMinRef.value.style.flexBasis = `calc(50% + ${thumbWidthVar})`;
-    inputMinRef.value.min = artificialMin.toString();
-    inputMinRef.value.max = artificialMid.toString();
-
-    inputMaxRef.value.style.flexBasis = `calc(50% + ${thumbWidthVar})`;
-    inputMaxRef.value.min = artificialMid.toString();
-    inputMaxRef.value.max = artificialMax.toString();
-
-    // Ambos os thumbs ficam no final de seus ranges (100%)
-    inputMinRef.value.style.setProperty('--gradient-position', `calc(100% + (-0.5 * ${thumbWidthVar}))`);
-    inputMaxRef.value.style.setProperty('--gradient-position', `calc(0% + (0.5 * ${thumbWidthVar}))`);
-    return;
-  }
-
-  // Cálculo normal: divide o range baseado no ponto médio
-  const leftWidthPercent = (((mid - min) / range) * 100).toFixed(props.precision);
-  const rightWidthPercent = (((max - mid) / range) * 100).toFixed(props.precision);
-
-  inputMinRef.value.style.flexBasis = `calc(${leftWidthPercent}% + ${thumbWidthVar})`;
-  inputMinRef.value.min = min.toString();
-  inputMinRef.value.max = mid.toFixed(props.precision);
-
-  inputMaxRef.value.style.flexBasis = `calc(${rightWidthPercent}% + ${thumbWidthVar})`;
-  inputMaxRef.value.min = mid.toFixed(props.precision);
-  inputMaxRef.value.max = max.toString();
-
-  const minRange = mid - min;
-  const maxRange = max - mid;
-
-  const minFill = (minValue - min) / minRange || 0;
-  const maxFill = (maxValue - mid) / maxRange || 0;
-
-  const minFillPercentage = (minFill * 100).toFixed(props.precision);
-  const maxFillPercentage = (maxFill * 100).toFixed(props.precision);
-
-  const minFillThumb = (0.5 - minFill).toFixed(props.precision);
-  const maxFillThumb = (0.5 - maxFill).toFixed(props.precision);
-
-  inputMinRef.value.style.setProperty(
-    '--gradient-position',
-    `calc(${minFillPercentage}% + (${minFillThumb} * ${thumbWidthVar}))`,
-  );
-
-  inputMaxRef.value.style.setProperty(
-    '--gradient-position',
-    `calc(${maxFillPercentage}% + (${maxFillThumb} * ${thumbWidthVar}))`,
-  );
-}
-
-function atualizarMin(event: Event): void {
+function onChange(event: Event) {
   const target = event.target as HTMLInputElement;
-  const novo = parseFloat(target.value);
-  sliderMin.value = novo;
-  setMin(novo);
-  updateRanges('ceil');
+  emit('update:modelValue', Number(target.value));
 }
-
-function atualizarMax(event: Event): void {
-  const target = event.target as HTMLInputElement;
-  const novo = parseFloat(target.value);
-  sliderMax.value = novo;
-  setMax(novo);
-  updateRanges('floor');
-}
-
-function handleMinFocus(): void {
-  updateRanges('ceil');
-}
-
-function handleMaxFocus(): void {
-  updateRanges('floor');
-}
-
-const inputMinValue = ref<string>('');
-const inputMaxValue = ref<string>('');
-
-function formatarParaInput(valor: number): string {
-  if (props.formatarMoeda) {
-    return dinheiro(valor, { style: 'decimal' });
-  }
-  return valor.toString();
-}
-
-watch(() => props.min, (): void => {
-  updateRanges('ceil');
-});
-
-watch(() => props.max, (): void => {
-  updateRanges('ceil');
-});
-
-watch(() => props.minSelecionado, (novo): void => {
-  if (novo !== null && novo !== undefined) {
-    sliderMin.value = novo;
-    setMin(novo);
-    updateRanges('ceil');
-  }
-});
-
-watch(() => props.maxSelecionado, (novo): void => {
-  if (novo !== null && novo !== undefined) {
-    sliderMax.value = novo;
-    setMax(novo);
-    updateRanges('floor');
-  }
-});
-
-watch(valorMin, (novo: number | string | null | undefined): void => {
-  if (novo !== undefined && novo !== null && novo !== '') {
-    const valor = parseFloat(String(novo));
-    if (valor !== sliderMin.value) {
-      sliderMin.value = Math.max(props.min, Math.min(Math.min(props.max, sliderMax.value), valor));
-      updateRanges('ceil');
-    }
-  }
-});
-
-watch(valorMax, (novo: number | string | null | undefined): void => {
-  if (novo !== undefined && novo !== null && novo !== '') {
-    const valor = parseFloat(String(novo));
-    if (valor !== sliderMax.value) {
-      sliderMax.value = Math.max(Math.max(props.min, sliderMin.value), Math.min(props.max, valor));
-      updateRanges('floor');
-    }
-  }
-});
-
-watch(sliderMin, (valor: number): void => {
-  inputMinValue.value = formatarParaInput(valor);
-});
-
-watch(sliderMax, (valor: number): void => {
-  inputMaxValue.value = formatarParaInput(valor);
-});
-
-onMounted(async (): Promise<void> => {
-  await nextTick();
-
-  if (inputMinRef.value && inputMaxRef.value) {
-    inputMinRef.value.min = props.min.toString();
-    inputMinRef.value.max = props.max.toString();
-    inputMaxRef.value.min = props.min.toString();
-    inputMaxRef.value.max = props.max.toString();
-  }
-  inputMinValue.value = formatarParaInput(sliderMin.value);
-  inputMaxValue.value = formatarParaInput(sliderMax.value);
-
-  updateRanges('ceil');
-  ready.value = true;
-});
-
-function atualizarMinViaInput(event: Event): void {
-  const target = event.target as HTMLInputElement;
-  const valorString = target.value;
-  const valor = toFloat(valorString);
-
-  if (!Number.isNaN(valor)) {
-    sliderMin.value = Math.max(props.min, Math.min(Math.min(props.max, sliderMax.value), valor));
-    setMin(sliderMin.value);
-    updateRanges('ceil');
-    inputMinValue.value = formatarParaInput(sliderMin.value);
-  }
-}
-
-function atualizarMaxViaInput(event: Event): void {
-  const target = event.target as HTMLInputElement;
-  const valorString = target.value;
-  const valor = toFloat(valorString);
-
-  if (!Number.isNaN(valor)) {
-    sliderMax.value = Math.max(Math.max(props.min, sliderMin.value), Math.min(props.max, valor));
-    setMax(sliderMax.value);
-    updateRanges('floor');
-    inputMaxValue.value = formatarParaInput(sliderMax.value);
-  }
-}
-
-const valorMinFormatado = computed<string | number>(() => (
-  props.formatarMoeda
-    ? dinheiro(sliderMin.value, { style: 'currency', currency: 'BRL' })
-    : sliderMin.value
-));
-
-const valorMaxFormatado = computed<string | number>(() => (
-  props.formatarMoeda
-    ? dinheiro(sliderMax.value, { style: 'currency', currency: 'BRL' })
-    : sliderMax.value
-));
-
-const isReadonly = computed<boolean>(() => props.min === props.max);
 </script>
 
 <template>
-  <div class="smae-range-input">
-    <div
-      class="range-wrapper"
-      :style="{ '--thumb-width': thumbWidthVar, '--track-height': '4px' }"
-    >
-      <input
-        ref="inputMinRef"
-        type="range"
-        :step="stepCalculado"
-        :value="sliderMin"
-        :data-ready="ready"
-        :data-readonly="isReadonly"
-        :aria-readonly="isReadonly"
-        class="range-input"
-        :aria-label="mostrarInputs ? 'Slider valor mínimo' : 'Valor mínimo'"
-        @input="atualizarMin"
-        @focus="handleMinFocus"
-        @mousedown="handleMinFocus"
-        @touchstart="handleMinFocus"
-      >
-
-      <input
-        ref="inputMaxRef"
-        type="range"
-        :step="stepCalculado"
-        :value="sliderMax"
-        :data-ready="ready"
-        :data-readonly="isReadonly"
-        :aria-readonly="isReadonly"
-        class="range-input"
-        :aria-label="mostrarInputs ? 'Slider valor máximo' : 'Valor máximo'"
-        @input="atualizarMax"
-        @focus="handleMaxFocus"
-        @mousedown="handleMaxFocus"
-        @touchstart="handleMaxFocus"
-      >
-    </div>
-
-    <div
-      v-if="!mostrarInputs"
-      class="range-labels flex space-between mt1"
-    >
-      <span class="range-label">{{ valorMinFormatado }}</span>
-      <span class="range-label">{{ valorMaxFormatado }}</span>
-    </div>
-
-    <div
-      v-else
-      class="range-inputs flex g2 mt1"
-    >
-      <div class="f1 flex">
-        <span
-          v-if="formatarMoeda"
-          class="input-prefix"
-        >R$</span>
-        <input
-          v-model="inputMinValue"
-          :type="formatarMoeda ? 'text' : 'number'"
-          :min="formatarMoeda ? undefined : min"
-          :max="formatarMoeda ? undefined : max"
-          :step="formatarMoeda ? undefined : stepCalculado"
-          :readonly="isReadonly"
-          :class="['inputtext light', { 'with-prefix': formatarMoeda }]"
-          placeholder="Mínimo"
-          aria-label="Valor mínimo"
-          @change="atualizarMinViaInput"
-          @keyup.enter="atualizarMinViaInput"
-        >
-      </div>
-      <div class="f1 flex">
-        <span
-          v-if="formatarMoeda"
-          class="input-prefix"
-        >R$</span>
-        <input
-          v-model="inputMaxValue"
-          :type="formatarMoeda ? 'text' : 'number'"
-          :min="formatarMoeda ? undefined : min"
-          :max="formatarMoeda ? undefined : max"
-          :readonly="isReadonly"
-          :step="formatarMoeda ? undefined : stepCalculado"
-          :class="['inputtext light', { 'with-prefix': formatarMoeda }]"
-          placeholder="Máximo"
-          aria-label="Valor máximo"
-          @change="atualizarMaxViaInput"
-          @keyup.enter="atualizarMaxViaInput"
-        >
-      </div>
-    </div>
-
-    <input
-      type="hidden"
-      :name="nameMin"
-      :value="sliderMin"
-    >
-    <input
-      type="hidden"
-      :name="nameMax"
-      :value="sliderMax"
-    >
-  </div>
+  <input
+    type="range"
+    :name="name"
+    :min="min"
+    :max="max"
+    :step="step"
+    :value="modelValue"
+    :style="{ '--inputrange-fill': fill }"
+    @input="onChange"
+  >
 </template>
 
 <style lang="less" scoped>
-@import '@/_less/variables.less';
+input {
+  --inputrange-thumb-size: 20px;
+  --inputrange-track-height: 4px;
 
-.smae-range-input {
-  position: relative;
-  padding: 0.5rem 0;
-}
-
-.range-wrapper {
-  display: flex;
-  height: 1.5rem;
-  max-width: 100%;
-  width: 100%;
-  box-sizing: border-box;
-  // Padding apenas na direita para acomodar os thumbs
-  padding-inline-end: calc(var(--thumb-width) * 2);
-}
-
-.range-input {
-  -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   background: none;
   border-radius: 0;
-  // Flexbox: começa em 50% + thumb width
-  flex-basis: calc(50% + var(--thumb-width));
-  flex-shrink: 0;
   font-size: inherit;
-  height: 100%;
   margin: 0;
-  min-width: var(--thumb-width);
+  min-width: var(--inputrange-thumb-size);
   outline: none;
   cursor: pointer;
-  pointer-events: all;
+  width: 100%;
 
-  // === WEBKIT (Chrome, Safari, Edge) ===
-
-  // Track base
   &::-webkit-slider-runnable-track {
     background-color: @c200;
+    background-image: linear-gradient(
+      to right,
+      @amarelo var(--inputrange-fill, 0%),
+      @c200 var(--inputrange-fill, 0%)
+    );
     background-repeat: no-repeat;
     box-sizing: border-box;
-    height: var(--track-height);
+    height: var(--inputrange-track-height);
+    border-radius: 1rem;
     cursor: pointer;
   }
 
-  // Track do input MIN (first-child)
-  &:first-child::-webkit-slider-runnable-track {
-    border-start-start-radius: 1rem;
-    border-end-start-radius: 1rem;
-    // Cinza até gradient-position, depois amarelo
+  &::-moz-range-track {
+    background-color: @c200;
     background-image: linear-gradient(
       to right,
-      @c200 var(--gradient-position),
-      @amarelo var(--gradient-position),
-      @amarelo
+      @amarelo var(--inputrange-fill, 0%),
+      @c200 var(--inputrange-fill, 0%)
     );
+    background-repeat: no-repeat;
+    box-sizing: border-box;
+    height: var(--inputrange-track-height);
+    border-radius: 1rem;
+    cursor: pointer;
   }
 
-  // Track do input MAX (last-child)
-  &:last-child::-webkit-slider-runnable-track {
-    border-start-end-radius: 1rem;
-    border-end-end-radius: 1rem;
-    // Amarelo até gradient-position, depois cinza
-    background-image: linear-gradient(
-      to right,
-      @amarelo,
-      @amarelo var(--gradient-position),
-      @c200 var(--gradient-position)
-    );
-  }
-
-  // Thumb
   &::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: var(--thumb-width);
-    height: var(--thumb-width);
-    margin-top: calc(var(--track-height) / 2);
+    width: var(--inputrange-thumb-size);
+    height: var(--inputrange-thumb-size);
+    margin-top: calc(var(--inputrange-track-height) / 2);
     transform: translateY(-50%);
     background-color: @amarelo;
     border-radius: 50%;
@@ -498,56 +117,9 @@ const isReadonly = computed<boolean>(() => props.min === props.max);
     }
   }
 
-  // Esconder thumbs até estar pronto
-  &:not([data-ready="true"])::-webkit-slider-thumb {
-    opacity: 0;
-  }
-
-  &:focus-visible::-webkit-slider-thumb {
-    box-shadow: 0 0 0 3px fade(@amarelo, 30%), 0 2px 6px rgba(0, 0, 0, 0.2);
-  }
-
-  // === FIREFOX ===
-
-  // Track base
-  &::-moz-range-track {
-    background-color: @c200;
-    background-repeat: no-repeat;
-    box-sizing: border-box;
-    height: var(--track-height);
-    cursor: pointer;
-  }
-
-  // Track do input MIN (first-child)
-  &:first-child::-moz-range-track {
-    border-start-start-radius: 1rem;
-    border-end-start-radius: 1rem;
-    // Cinza até gradient-position, depois amarelo
-    background-image: linear-gradient(
-      to right,
-      @c200 var(--gradient-position),
-      @amarelo var(--gradient-position),
-      @amarelo
-    );
-  }
-
-  // Track do input MAX (last-child)
-  &:last-child::-moz-range-track {
-    border-start-end-radius: 1rem;
-    border-end-end-radius: 1rem;
-    // Amarelo até gradient-position, depois cinza
-    background-image: linear-gradient(
-      to right,
-      @amarelo,
-      @amarelo var(--gradient-position),
-      @c200 var(--gradient-position)
-    );
-  }
-
-  // Thumb
   &::-moz-range-thumb {
-    width: var(--thumb-width);
-    height: var(--thumb-width);
+    width: var(--inputrange-thumb-size);
+    height: var(--inputrange-thumb-size);
     background-color: @amarelo;
     border-radius: 50%;
     cursor: grab;
@@ -568,59 +140,18 @@ const isReadonly = computed<boolean>(() => props.min === props.max);
     }
   }
 
-  // Esconder thumbs até estar pronto
-  &:not([data-ready="true"])::-moz-range-thumb {
-    opacity: 0;
+  &:focus-visible::-webkit-slider-thumb {
+    box-shadow: 0 0 0 3px fade(@amarelo, 30%), 0 2px 6px rgba(0, 0, 0, 0.2);
   }
 
   &:focus-visible::-moz-range-thumb {
     box-shadow: 0 0 0 3px fade(@amarelo, 30%), 0 2px 6px rgba(0, 0, 0, 0.2);
   }
 
-  // Estado readonly: desabilita interação
-  &[data-readonly="true"] {
+  &:disabled {
     pointer-events: none;
     opacity: 0.6;
     cursor: not-allowed;
-  }
-}
-
-// Focus no wrapper quando qualquer input tiver foco
-.range-wrapper:has(input:focus-visible) {
-  outline: 2px solid fade(@amarelo, 50%);
-  outline-offset: 4px;
-  border-radius: 2px;
-}
-
-.range-labels {
-  user-select: none;
-}
-
-.range-label {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: @c600;
-}
-
-// Inputs editáveis
-.range-inputs {
-  .input-prefix {
-    display: flex;
-    align-items: center;
-    padding: 0.5rem 0.75rem;
-    background-color: @c100;
-    border: 1px solid @c200;
-    border-right: none;
-    border-radius: 4px 0 0 4px;
-    font-weight: 500;
-    color: @c600;
-    font-size: 0.875rem;
-    white-space: nowrap;
-  }
-
-  .with-prefix {
-    border-radius: 0 4px 4px 0;
-    flex: 1;
   }
 }
 </style>

--- a/frontend/src/views/publico/demanda/DemandasLista.vue
+++ b/frontend/src/views/publico/demanda/DemandasLista.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
 
 import CabecalhoDePagina from '@/components/CabecalhoDePagina.vue';
-import SmaeRangeInput from '@/components/camposDeFormulario/SmaeRangeInput.vue';
+import SmaeDoubleRangeInput from '@/components/camposDeFormulario/SmaeDoubleRangeInput.vue';
 import * as CardEnvelope from '@/components/cardEnvelope';
 import ErrorComponent from '@/components/ErrorComponent.vue';
 import FormularioQueryString from '@/components/FormularioQueryString.vue';
@@ -435,7 +435,7 @@ const camadasParaMapa = computed(() => camadasGeo.value.map((camada) => ({
         <div class="flex g2 flexwrap">
           <div class="f1">
             <label class="label">Valor</label>
-            <SmaeRangeInput
+            <SmaeDoubleRangeInput
               v-if="filtros?.valor_range"
               name-min="valor_min"
               name-max="valor_max"

--- a/frontend/src/views/tarefas/TarefasLista.vue
+++ b/frontend/src/views/tarefas/TarefasLista.vue
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router';
 
-import SmaeRange from '@/components/camposDeFormulario/SmaeRange.vue';
+import SmaeRangeInput from '@/components/camposDeFormulario/SmaeRangeInput.vue';
 import ListaLegendas from '@/components/ListaLegendas.vue';
 import LinhaDeCronograma from '@/components/projetos/LinhaDeCronograma.vue';
 import CabecalhoResumo from '@/components/tarefas/CabecalhoResumo.vue';
@@ -248,7 +248,7 @@ onUnmounted(() => {
     <div class="">
       <label class="label tc300"> Exibir tarefas até nível </label>
       <div class="flex g1 center">
-        <SmaeRange
+        <SmaeRangeInput
           id="nivel"
           v-model="nívelMáximoVisível"
           name="nivel"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dual-range slider component with synchronized minimum and maximum value selection, optional currency formatting, editable numeric input fields, and configurable step values for precise adjustments.

* **Refactor**
  * Simplified single-range slider component with streamlined configuration and API, reducing complexity for basic value selection use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->