### PR TITLE
feat(demandas): adicionando emails para parlamentares e endpoints

### DIFF
--- a/backend/src/casa-civil/demanda/demanda.controller.ts
+++ b/backend/src/casa-civil/demanda/demanda.controller.ts
@@ -10,6 +10,7 @@ import { CreateDemandaDto } from './dto/create-demanda.dto';
 import { FilterDemandaDto } from './dto/filter-demanda.dto';
 import { UpdateDemandaDto } from './dto/create-demanda.dto';
 import { DemandaDetailDto, DemandaHistoricoDto, ListDemandaDto } from './entities/demanda.entity';
+import { ListDemandaEmailParlamentarDto } from './entities/demanda-email-parlamentar.entity';
 import { CreateDemandaAcaoDto } from './dto/acao.dto';
 import { OrgaoReduzidoDto } from 'src/orgao/entities/orgao.entity';
 
@@ -75,6 +76,27 @@ export class DemandaController {
         @CurrentUser() user: PessoaFromJwt
     ): Promise<DemandaHistoricoDto[]> {
         return await this.demandaService.getHistorico(+params.id, user);
+    }
+
+    @Post(':id/enviar-email-parlamentares')
+    @ApiBearerAuth('access-token')
+    @Roles(['CadastroDemanda.validar']) // Apenas SERI pode enviar emails
+    @ApiResponse({ description: 'E-mails enviados com sucesso', status: 200 })
+    async enviarEmailParlamentares(
+        @Param() params: FindOneParams,
+        @CurrentUser() user: PessoaFromJwt
+    ): Promise<{ id: string }[]> {
+        return await this.demandaService.enviarEmailParaParlamentares(+params.id, user);
+    }
+
+    @Get(':id/emails-parlamentares')
+    @ApiBearerAuth('access-token')
+    @Roles(['CadastroDemanda.listar'])
+    async listarEmailsParlamentares(
+        @Param() params: FindOneParams,
+        @CurrentUser() user: PessoaFromJwt
+    ): Promise<ListDemandaEmailParlamentarDto> {
+        return await this.demandaService.listarEmailsParlamentares(+params.id, user);
     }
 }
 

--- a/backend/src/casa-civil/demanda/entities/demanda-email-parlamentar.entity.ts
+++ b/backend/src/casa-civil/demanda/entities/demanda-email-parlamentar.entity.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DemandaEmailParlamentarDto {
+    @ApiProperty()
+    id: string; // UUID do email na fila
+
+    @ApiProperty()
+    parlamentar: {
+        id: number;
+        nome: string;
+        nome_popular: string;
+        cargo: string;
+        partido: string;
+        uf: string;
+    } | null;
+
+    @ApiProperty()
+    email_enviado: string;
+
+    @ApiProperty()
+    assunto: string;
+
+    @ApiProperty()
+    criado_em: string;
+}
+
+export class ListDemandaEmailParlamentarDto {
+    linhas: DemandaEmailParlamentarDto[];
+}

--- a/backend/src/public/email-src/emails/parlamentar-convite-emendas.mjml
+++ b/backend/src/public/email-src/emails/parlamentar-convite-emendas.mjml
@@ -1,0 +1,36 @@
+<mjml>
+  <mj-include path="../components/head.mjml" />
+  <mj-body background-color="#011c50">
+    <mj-include path="../components/header.mjml" />
+
+    <mj-section background-color="#fff">
+      <mj-column>
+        <mj-text>
+          <p>À Sua Excelência,</p>
+          
+          <p>Senhor(a) [% cargo_parlamentar %]</p>
+          
+          <p>[% nome_parlamentar %]</p>
+          
+          <br/>
+          
+          <p>Reafirmo o interesse da Prefeitura de São Paulo em fortalecer a parceria entre V.Exa e o nosso município através da execução de Emendas Parlamentares.</p>
+          
+          <p>Aproveito para encaminhar propostas de demandas do nosso município, que poderão ensejar a formulação de Emendas Parlamentares à LOA. As propostas de demandas estão disponíveis através do site <a href="[% link_portfolio %]">[% link_portfolio %]</a></p>
+          
+          <p>Ressalto a possibilidade da destinação de outras Emendas de acordo com o vosso trabalho no interesse do nosso município.</p>
+          
+          <p>Destaco também que o quanto antes for apresentado interesse em indicar emendas para o município de São Paulo, maior a exequibilidade das demandas.</p>
+          
+          <p>Nosso apreço e gratidão pela atenção sempre dispensada a esta municipalidade.</p>
+          
+          <p>Atenciosamente,<br/>
+          SERI – [% orgao_nome %]</p>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-include path="../components/footer.mjml" />
+
+  </mj-body>
+</mjml>

--- a/backend/src/public/email-templates/parlamentar-convite-emendas.html
+++ b/backend/src/public/email-templates/parlamentar-convite-emendas.html
@@ -1,0 +1,297 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title>[% subject %]</title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+
+  </style>
+  <!--<![endif]-->
+  <style type="text/css">
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+
+      .mj-column-per-40 {
+        width: 40% !important;
+        max-width: 40%;
+      }
+
+      .mj-column-per-60 {
+        width: 60% !important;
+        max-width: 60%;
+      }
+    }
+
+  </style>
+  <style media="screen and (min-width:480px)">
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+
+    .moz-text-html .mj-column-per-40 {
+      width: 40% !important;
+      max-width: 40%;
+    }
+
+    .moz-text-html .mj-column-per-60 {
+      width: 60% !important;
+      max-width: 60%;
+    }
+
+  </style>
+  <style type="text/css">
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile {
+        width: 100% !important;
+      }
+
+      td.mj-full-width-mobile {
+        width: auto !important;
+      }
+    }
+
+  </style>
+</head>
+
+<body style="word-spacing:normal;background-color:#011c50;">
+  <div aria-label="[% subject %]" aria-roledescription="email" style="background-color:#011c50;" role="article" lang="und" dir="auto">
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+      <tbody>
+        <tr>
+          <td>
+            <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+            <div style="margin:0px auto;max-width:600px;">
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                <tbody>
+                  <tr>
+                    <td style="direction:ltr;font-size:0px;padding:0;padding-bottom:0;text-align:center;">
+                      <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                          <tbody>
+                            <tr>
+                              <td style="vertical-align:top;padding:0;">
+                                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
+                                  <tbody>
+                                    <tr>
+                                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+                                          <tbody>
+                                            <tr>
+                                              <td style="width:600px;">
+                                                <img alt="Logo do SMAE" src="https://homol-smae-api.appcivico.com/public/email-templates/img/header.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto" />
+                                              </td>
+                                            </tr>
+                                          </tbody>
+                                        </table>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                      <!--[if mso | IE]></td></tr></table><![endif]-->
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                  <tbody>
+                    <tr>
+                      <td style="vertical-align:top;padding:0;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                <div style="font-family:'Arial', 'Helvetica Neue', 'Helvetica', sans-serif;font-size:16px;line-height:24px;text-align:left;color:#202020;">
+                                  <p>À Sua Excelência,</p>
+                                  <p>Senhor(a) [% cargo_parlamentar %]</p>
+                                  <p>[% nome_parlamentar %]</p>
+                                  <br />
+                                  <p>Reafirmo o interesse da Prefeitura de São Paulo em fortalecer a parceria entre V.Exa e o nosso município através da execução de Emendas Parlamentares.</p>
+                                  <p>Aproveito para encaminhar propostas de demandas do nosso município, que poderão ensejar a formulação de Emendas Parlamentares à LOA. As propostas de demandas estão disponíveis através do site <a href="[% link_portfolio %]">[% link_portfolio %]</a></p>
+                                  <p>Ressalto a possibilidade da destinação de outras Emendas de acordo com o vosso trabalho no interesse do nosso município.</p>
+                                  <p>Destaco também que o quanto antes for apresentado interesse em indicar emendas para o município de São Paulo, maior a exequibilidade das demandas.</p>
+                                  <p>Nosso apreço e gratidão pela atenção sempre dispensada a esta municipalidade.</p>
+                                  <p>Atenciosamente,<br /> SERI – [% orgao_nome %]</p>
+                                </div>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#00205B" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#00205B;background-color:#00205B;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#00205B;background-color:#00205B;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:20px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:224px;" ><![endif]-->
+              <div class="mj-column-per-40 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                  <tbody>
+                    <tr>
+                      <td style="vertical-align:top;padding:0;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="font-size:0px;padding:0;padding-left:20px;word-break:break-word;">
+                                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+                                  <tbody>
+                                    <tr>
+                                      <td style="width:120px;">
+                                        <img alt="" src="https://homol-smae-api.appcivico.com/public/email-templates/img/smae-logo.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="120" height="auto" />
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td align="left" style="font-size:0px;padding:10px 25px;padding-top:10px;word-break:break-word;">
+                                <div style="font-family:'Arial', 'Helvetica Neue', 'Helvetica', sans-serif;font-size:14px;line-height:24px;text-align:left;color:#ffffff;"><!-- <a href="#" style="color: #ffffff; text-decoration: none;">Sobre</a> -->
+                                  <br>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td align="left" style="font-size:0px;padding:10px 25px;padding-top:5px;word-break:break-word;">
+                                <div style="font-family:'Arial', 'Helvetica Neue', 'Helvetica', sans-serif;font-size:14px;line-height:24px;text-align:left;color:#ffffff;"><br>
+                                  <!-- <a href="#" style="color: #ffffff; text-decoration: none;">Contato</a> --></div>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td><td class="" style="vertical-align:bottom;width:336px;" ><![endif]-->
+              <div class="mj-column-per-60 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:bottom;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                  <tbody>
+                    <tr>
+                      <td style="vertical-align:bottom;padding:0;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="font-size:0px;padding:10px 25px;padding-top:20px;word-break:break-word;">
+                                <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                  <tr>
+                                    <td style="text-align: right; width: 50%; padding-right: 10px;">
+                                      <img src="https://homol-smae-api.appcivico.com/public/email-templates/img/fgv-logo.png" width="120px" alt="FGV" style="vertical-align: bottom;" />
+                                    </td>
+                                    <td style="text-align: right; width: 50%;">
+                                      <img src="https://homol-smae-api.appcivico.com/public/email-templates/img/sp-logo.png" width="120px" alt="São Paulo" style="vertical-align: bottom;" />
+                                    </td>
+                                  </tr>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Send invitation emails to elected parliamentarians related to specific demand proposals with automatic tracking and comprehensive status monitoring
* View, manage, and track all sent parliamentary emails including recipient details, subject lines, and precise send timestamps
* New customizable email template for parliamentary communications with personalized dynamic content support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->