### PR TITLE
refactor(distribuicao-recurso): remover privilégio anti-access SMAE.gestor_distribuicao_recurso

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1316,6 +1316,10 @@ const PerfilAcessoConfig: PerfilConfigArray = [
 
             'Reports.executar.CasaCivilGestorDistRec',
             'Reports.remover.CasaCivilGestorDistRec',
+
+            'CadastroTransferencia.listar',
+            'AndamentoWorkflow.listar',
+            'CadastroCronogramaTransferencia.listar',
         ],
     },
     {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -605,7 +605,6 @@ const PrivConfig: Record<string, false | [ListaDePrivilegios, string | false][]>
         ['SMAE.superadmin', 'Faz parte do perfil de Administrador Geral'],
         ['SMAE.loga_direto_na_analise', 'Acesso direto à parte de análise ao fazer login'],
         ['PerfilAcesso.administrador', 'Gerenciar Perfil de Acesso'],
-        ['SMAE.gestor_distribuicao_recurso', 'Visão limitada, para gestor de distribuição de recurso'],
         ['SMAE.AtualizacaoEmLote', 'Acesso a ferramenta de atualização em lote'],
         ['SMAE.gerente_de_projeto', 'Editar os responsáveis de projetos após a fase de planejamento'],
     ],
@@ -1286,9 +1285,6 @@ const PerfilAcessoConfig: PerfilConfigArray = [
         nome: atualizarNomePerfil('Gestor(a) de Distribuição de Recurso', ['Gestor de Distribuição de Recurso']),
         descricao: 'Pode visualizar todas as distribuições de recurso para seu órgão.',
         privilegios: [
-            // Privs utilizadas para refinamento de controle de permissão em endpoints que possuem "pode_editar".
-            'SMAE.gestor_distribuicao_recurso',
-
             'CadastroAreaTematica.listar',
             'CadastroDemandaConfig.listar',
 
@@ -1442,6 +1438,7 @@ async function main() {
             if (!locked[0].locked) return;
 
             await remover_feature_flags_obsoletas();
+            await remover_privilegios_obsoletos();
             await criar_emaildb_config();
             await criar_texto_config();
             await atualizar_modulos_e_privilegios();
@@ -1651,6 +1648,21 @@ async function remover_feature_flags_obsoletas() {
         where: {
             key: { in: ['LIBERA_SPRINT_30', 'LIBERA_SPRINT_31'] },
         },
+    });
+}
+
+async function remover_privilegios_obsoletos() {
+    // Remoção explícita de privilégios descontinuados.
+    // A FK em perfil_privilegio não cascateia (onDelete: NoAction),
+    // por isso é necessário limpar a tabela associativa antes.
+    const codigosObsoletos = ['SMAE.gestor_distribuicao_recurso'];
+
+    await prisma.perfilPrivilegio.deleteMany({
+        where: { privilegio: { codigo: { in: codigosObsoletos } } },
+    });
+
+    await prisma.privilegio.deleteMany({
+        where: { codigo: { in: codigosObsoletos } },
     });
 }
 

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1438,7 +1438,6 @@ async function main() {
             if (!locked[0].locked) return;
 
             await remover_feature_flags_obsoletas();
-            await remover_privilegios_obsoletos();
             await criar_emaildb_config();
             await criar_texto_config();
             await atualizar_modulos_e_privilegios();
@@ -1648,21 +1647,6 @@ async function remover_feature_flags_obsoletas() {
         where: {
             key: { in: ['LIBERA_SPRINT_30', 'LIBERA_SPRINT_31'] },
         },
-    });
-}
-
-async function remover_privilegios_obsoletos() {
-    // Remoção explícita de privilégios descontinuados.
-    // A FK em perfil_privilegio não cascateia (onDelete: NoAction),
-    // por isso é necessário limpar a tabela associativa antes.
-    const codigosObsoletos = ['SMAE.gestor_distribuicao_recurso'];
-
-    await prisma.perfilPrivilegio.deleteMany({
-        where: { privilegio: { codigo: { in: codigosObsoletos } } },
-    });
-
-    await prisma.privilegio.deleteMany({
-        where: { codigo: { in: codigosObsoletos } },
     });
 }
 

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1298,6 +1298,9 @@ const PerfilAcessoConfig: PerfilConfigArray = [
             'CadastroDistribuicaoSolicitacaoAjuste.editar',
             'CadastroDistribuicaoSolicitacaoAjuste.listar',
             'CadastroDistribuicaoSolicitacaoAjuste.remover',
+
+            'Reports.executar.CasaCivil',
+            'Reports.remover.CasaCivil',
         ],
     },
     {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -15,6 +15,7 @@ import {
     CONST_PERFIL_CASA_CIVIL,
     CONST_PERFIL_COLAB_OBRA_NO_ORGAO,
     CONST_PERFIL_COORDENADOR_EQUIPE,
+    CONST_PERFIL_GESTOR_DIST_RECURSO,
     CONST_PERFIL_GESTOR_OBRA,
     CONST_PERFIL_PARTICIPANTE_EQUIPE,
     CONST_PERFIL_PARTICIPANTE_EQUIPE_PDM,
@@ -536,7 +537,7 @@ const PrivConfig: Record<string, false | [ListaDePrivilegios, string | false][]>
     ],
     CadastroTransferencia: [
         ['CadastroTransferencia.administrador', 'Inserir, Listar e remover transferência de qualquer órgão'],
-        ['CadastroTransferencia.editar', 'Editar Transferência'],
+        ['CadastroTransferencia.editar', 'Editar Transferência'], // NUNCA adicione esse priv no CONST_PERFIL_GESTOR_DIST_RECURSO
         ['CadastroTransferencia.listar', 'Listar Transferência dos órgãos ao qual pertence'],
         ['CadastroTransferencia.inserir', 'Inserir Transferência'],
         ['CadastroTransferencia.remover', 'Remover Transferência'],
@@ -552,11 +553,17 @@ const PrivConfig: Record<string, false | [ListaDePrivilegios, string | false][]>
         ['CadastroTransferenciaAnexo.remover', 'Remover Anexo de Transferência'],
     ],
     CadastroDistribuicaoSolicitacaoAjuste: [
-        ['CadastroDistribuicaoSolicitacaoAjuste.inserir', 'Solicitar ajuste em distribuição de recurso do próprio órgão'],
+        [
+            'CadastroDistribuicaoSolicitacaoAjuste.inserir',
+            'Solicitar ajuste em distribuição de recurso do próprio órgão',
+        ],
         ['CadastroDistribuicaoSolicitacaoAjuste.editar', 'Editar solicitação de ajuste pendente'],
         ['CadastroDistribuicaoSolicitacaoAjuste.listar', 'Listar solicitações de ajuste'],
         ['CadastroDistribuicaoSolicitacaoAjuste.remover', 'Remover solicitação de ajuste pendente'],
-        ['CadastroDistribuicaoSolicitacaoAjuste.administrador', 'Gerir (aprovar/recusar) solicitações de ajuste de distribuição'],
+        [
+            'CadastroDistribuicaoSolicitacaoAjuste.administrador',
+            'Gerir (aprovar/recusar) solicitações de ajuste de distribuição',
+        ],
     ],
     CadastroWorkflow: [
         ['CadastroWorkflows.editar', 'Editar Workflows'],
@@ -595,6 +602,14 @@ const PrivConfig: Record<string, false | [ListaDePrivilegios, string | false][]>
     ReportsCasaCivil: [
         ['Reports.executar.CasaCivil', 'Executar relatórios de transferências voluntárias'],
         ['Reports.remover.CasaCivil', 'Executar relatórios de transferências voluntárias'],
+        [
+            'Reports.executar.CasaCivilGestorDistRec',
+            'Executar relatórios de Demandas (escopo Gestor de Distribuição de Recurso)',
+        ],
+        [
+            'Reports.remover.CasaCivilGestorDistRec',
+            'Remover relatórios de Demandas (escopo Gestor de Distribuição de Recurso)',
+        ],
     ],
     PerfilAcesso: [['PerfilAcesso.administrador', false]],
     CadastroPainelExternoRegra: [['SMAE.espectador_de_painel_externo', 'Visualizador de painel externo']],
@@ -1282,7 +1297,7 @@ const PerfilAcessoConfig: PerfilConfigArray = [
         ],
     },
     {
-        nome: atualizarNomePerfil('Gestor(a) de Distribuição de Recurso', ['Gestor de Distribuição de Recurso']),
+        nome: atualizarNomePerfil(CONST_PERFIL_GESTOR_DIST_RECURSO, ['Gestor de Distribuição de Recurso']),
         descricao: 'Pode visualizar todas as distribuições de recurso para seu órgão.',
         privilegios: [
             'CadastroAreaTematica.listar',
@@ -1299,8 +1314,8 @@ const PerfilAcessoConfig: PerfilConfigArray = [
             'CadastroDistribuicaoSolicitacaoAjuste.listar',
             'CadastroDistribuicaoSolicitacaoAjuste.remover',
 
-            'Reports.executar.CasaCivil',
-            'Reports.remover.CasaCivil',
+            'Reports.executar.CasaCivilGestorDistRec',
+            'Reports.remover.CasaCivilGestorDistRec',
         ],
     },
     {

--- a/backend/src/bloco-nota/nota/nota.service.ts
+++ b/backend/src/bloco-nota/nota/nota.service.ts
@@ -766,15 +766,6 @@ export class NotaService {
             write = nota.orgao_responsavel_id == user.orgao_id;
         }
 
-        // Caso usuário tenha priv de gestor de distribuição de recurso (sem ser gestor de transferências)
-        // Não pode editar. Gestor de Transferências tem precedência.
-        if (
-            user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']) &&
-            !user.hasSomeRoles(['CadastroTransferencia.editar', 'CadastroTransferencia.administrador'])
-        ) {
-            write = false;
-        }
-
         return {
             token: this.jwtService.sign(
                 {

--- a/backend/src/casa-civil/distribuicao-recurso/distribuicao-recurso-status.service.ts
+++ b/backend/src/casa-civil/distribuicao-recurso/distribuicao-recurso-status.service.ts
@@ -92,11 +92,7 @@ export class DistribuicaoRecursoStatusService {
         dto: CreateDistribuicaoRecursoStatusDto,
         user: PessoaFromJwt
     ): Promise<RecordWithId> {
-        // Gestor de Distribuição de Recurso não pode criar status
-        if (user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso'])) {
-            throw new HttpException('Você não tem permissão para registrar status em distribuições.', 403);
-        }
-
+        // O acesso a este endpoint já é controlado pelo @Roles(['CadastroTransferencia.inserir']) no controller.
         if (dto.status_base_id == undefined && dto.status_id == undefined)
             throw new HttpException('É necessário enviar um ID de status.', 400);
 
@@ -212,11 +208,7 @@ export class DistribuicaoRecursoStatusService {
         dto: UpdateDistribuicaoRecursoStatusDto,
         user: PessoaFromJwt
     ): Promise<RecordWithId> {
-        // Gestor de Distribuição de Recurso não pode atualizar status
-        if (user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso'])) {
-            throw new HttpException('Você não tem permissão para atualizar status em distribuições.', 403);
-        }
-
+        // O acesso a este endpoint já é controlado pelo @Roles(['CadastroTransferencia.editar']) no controller.
         await this.prisma.$transaction(async (prismaTx: Prisma.TransactionClient): Promise<RecordWithId> => {
             // Verificando se existe status mais novo. Ou seja, não pode editar.
             const self = await prismaTx.distribuicaoRecursoStatus.findFirstOrThrow({
@@ -262,11 +254,7 @@ export class DistribuicaoRecursoStatusService {
     }
 
     async remove(distribuicao_id: number, id: number, user: PessoaFromJwt) {
-        // Gestor de Distribuição de Recurso não pode remover status
-        if (user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso'])) {
-            throw new HttpException('Você não tem permissão para remover status de distribuições.', 403);
-        }
-
+        // O acesso a este endpoint já é controlado pelo @Roles(['CadastroTransferencia.remover']) no controller.
         const exists = await this.prisma.distribuicaoRecursoStatus.findFirst({
             where: {
                 id,

--- a/backend/src/casa-civil/distribuicao-recurso/distribuicao-recurso.service.ts
+++ b/backend/src/casa-civil/distribuicao-recurso/distribuicao-recurso.service.ts
@@ -717,14 +717,10 @@ export class DistribuicaoRecursoService {
                     pode_registrar_status = false;
             }
 
-            // Gestor de Distribuição de Recurso não pode editar distribuições,
-            // a menos que também seja Gestor de Transferências (que tem precedência)
-            const isGestorDistribuicao = user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']);
-            const isGestorTransferencia = user.hasSomeRoles([
+            const pode_editar = user.hasSomeRoles([
                 'CadastroTransferencia.editar',
                 'CadastroTransferencia.administrador',
             ]);
-            const pode_editar = !isGestorDistribuicao || isGestorTransferencia;
 
             let pct_valor_transferencia: number = 0;
             if (r.transferencia.valor && r.valor) {
@@ -1048,14 +1044,10 @@ export class DistribuicaoRecursoService {
         });
         if (!row) throw new HttpException('Distribuição de recurso não encontrada.', 404);
 
-        // Gestor de Distribuição de Recurso não pode editar distribuições,
-        // a menos que também seja Gestor de Transferências (que tem precedência)
-        const isGestorDistribuicao = user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']);
-        const isGestorTransferencia = user.hasSomeRoles([
+        const pode_editar = user.hasSomeRoles([
             'CadastroTransferencia.editar',
             'CadastroTransferencia.administrador',
         ]);
-        const pode_editar = !isGestorDistribuicao || isGestorTransferencia;
 
         const historico_status: DistribuicaoHistoricoStatusDto[] = row.status.map((r) => {
             return {
@@ -1204,15 +1196,7 @@ export class DistribuicaoRecursoService {
     async update(id: number, dto: UpdateDistribuicaoRecursoDto, user: PessoaFromJwt): Promise<RecordWithId> {
         const self = await this.findOne(id, user);
 
-        // Gestor de Distribuição de Recurso não pode editar distribuições,
-        // a menos que também seja Gestor de Transferências (que tem precedência)
-        if (
-            user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']) &&
-            !user.hasSomeRoles(['CadastroTransferencia.editar', 'CadastroTransferencia.administrador'])
-        ) {
-            throw new HttpException('Você não tem permissão para editar distribuições.', 403);
-        }
-
+        // O acesso a este endpoint já é controlado pelo @Roles(['CadastroTransferencia.editar']) no controller.
         this.checkDuplicateSei(dto);
 
         if (dto.orgao_gestor_id != undefined && dto.orgao_gestor_id != self.orgao_gestor.id) {
@@ -1849,15 +1833,7 @@ export class DistribuicaoRecursoService {
     }
 
     async remove(id: number, user: PessoaFromJwt) {
-        // Gestor de Distribuição de Recurso não pode remover distribuições,
-        // a menos que também seja Gestor de Transferências (que tem precedência)
-        if (
-            user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']) &&
-            !user.hasSomeRoles(['CadastroTransferencia.editar', 'CadastroTransferencia.administrador'])
-        ) {
-            throw new HttpException('Você não tem permissão para remover distribuições.', 403);
-        }
-
+        // O acesso a este endpoint já é controlado pelo @Roles(['CadastroTransferencia.remover']) no controller.
         await this.prisma.$transaction(async (prismaTx: Prisma.TransactionClient) => {
             const self = await prismaTx.distribuicaoRecurso.findFirstOrThrow({
                 where: {

--- a/backend/src/casa-civil/transferencia/transferencia.service.ts
+++ b/backend/src/casa-civil/transferencia/transferencia.service.ts
@@ -1163,13 +1163,9 @@ export class TransferenciaService {
             return permissionsSet;
         }
 
-        // Usuários do perfil restrito de gestor de distribuição (que possuem
-        // CadastroDistribuicaoSolicitacaoAjuste.inserir mas não administram transferências)
+        // Usuários do perfil restrito "Gestor(a) de Distribuição de Recurso"
         // só veem transferências que possuem pelo menos uma distribuição do seu órgão.
-        if (
-            user.hasSomeRoles(['CadastroDistribuicaoSolicitacaoAjuste.inserir']) &&
-            !user.hasSomeRoles(['CadastroTransferencia.administrador'])
-        ) {
+        if (user.hasSomeRoles(['SMAE.PerfilGestorDistribuicaoRecurso'])) {
             if (!user.orgao_id) throw new BadRequestException('Usuário sem órgão associado.');
 
             permissionsSet.push({

--- a/backend/src/casa-civil/transferencia/transferencia.service.ts
+++ b/backend/src/casa-civil/transferencia/transferencia.service.ts
@@ -355,15 +355,7 @@ export class TransferenciaService {
     }
 
     async updateTransferencia(id: number, dto: UpdateTransferenciaDto, user: PessoaFromJwt): Promise<RecordWithId> {
-        // Gestor de Distribuição de Recurso não pode editar transferências,
-        // a menos que também seja Gestor de Transferências (que tem precedência)
-        if (
-            user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']) &&
-            !user.hasSomeRoles(['CadastroTransferencia.editar', 'CadastroTransferencia.administrador'])
-        ) {
-            throw new HttpException('Você não tem permissão para editar transferências.', 403);
-        }
-
+        // O acesso a este endpoint já é controlado pelo @Roles(['CadastroTransferencia.editar']) no controller.
         const agora = new Date(Date.now());
         let workflowCriado: boolean = false;
         const updated = await this.prisma.$transaction(
@@ -1171,12 +1163,12 @@ export class TransferenciaService {
             return permissionsSet;
         }
 
-        // Gestores de Distribuição de Recurso só veem transferências
-        // que possuem pelo menos uma distribuição do seu órgão.
-        // Exceto se também forem Gestores de Transferências (que têm precedência e veem tudo).
+        // Usuários do perfil restrito de gestor de distribuição (que possuem
+        // CadastroDistribuicaoSolicitacaoAjuste.inserir mas não administram transferências)
+        // só veem transferências que possuem pelo menos uma distribuição do seu órgão.
         if (
-            user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']) &&
-            !user.hasSomeRoles(['CadastroTransferencia.editar', 'CadastroTransferencia.administrador'])
+            user.hasSomeRoles(['CadastroDistribuicaoSolicitacaoAjuste.inserir']) &&
+            !user.hasSomeRoles(['CadastroTransferencia.administrador'])
         ) {
             if (!user.orgao_id) throw new BadRequestException('Usuário sem órgão associado.');
 
@@ -1642,14 +1634,10 @@ export class TransferenciaService {
         });
         if (!row) throw new HttpException('Transferência não encontrada.', 404);
 
-        // Gestor de Distribuição de Recurso não pode editar transferências,
-        // a menos que também seja Gestor de Transferências (que tem precedência)
-        const isGestorDistribuicao = user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']);
-        const isGestorTransferencia = user.hasSomeRoles([
+        const pode_editar = user.hasSomeRoles([
             'CadastroTransferencia.editar',
             'CadastroTransferencia.administrador',
         ]);
-        const pode_editar = !isGestorDistribuicao || isGestorTransferencia;
 
         return {
             id: row.id,
@@ -1761,15 +1749,7 @@ export class TransferenciaService {
     }
 
     async removeTransferencia(id: number, user: PessoaFromJwt) {
-        // Gestor de Distribuição de Recurso não pode remover transferências,
-        // a menos que também seja Gestor de Transferências (que tem precedência)
-        if (
-            user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']) &&
-            !user.hasSomeRoles(['CadastroTransferencia.editar', 'CadastroTransferencia.administrador'])
-        ) {
-            throw new HttpException('Você não tem permissão para remover transferências.', 403);
-        }
-
+        // O acesso a este endpoint já é controlado pelo @Roles(['CadastroTransferencia.remover']) no controller.
         await this.prisma.transferencia.update({
             where: { id },
             data: {
@@ -1780,15 +1760,7 @@ export class TransferenciaService {
     }
 
     async append_document(transferenciaId: number, dto: CreateTransferenciaAnexoDto, user: PessoaFromJwt) {
-        // Gestor de Distribuição de Recurso não pode adicionar documentos,
-        // a menos que também seja Gestor de Transferências (que tem precedência)
-        if (
-            user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']) &&
-            !user.hasSomeRoles(['CadastroTransferencia.editar', 'CadastroTransferencia.administrador'])
-        ) {
-            throw new HttpException('Você não tem permissão para adicionar documentos nesta transferência.', 403);
-        }
-
+        // O acesso a este endpoint já é controlado pelo @Roles(['CadastroTransferenciaAnexo.inserir']) no controller.
         const arquivoId = this.uploadService.checkUploadOrDownloadToken(dto.upload_token);
 
         const documento = await this.prisma.$transaction(
@@ -1837,12 +1809,10 @@ export class TransferenciaService {
             },
         });
 
-        const isGestorDistribuicao = user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']);
-        const isGestorTransferencia = user.hasSomeRoles([
+        const pode_editar: boolean = user.hasSomeRoles([
             'CadastroTransferencia.editar',
             'CadastroTransferencia.administrador',
         ]);
-        const pode_editar: boolean = !isGestorDistribuicao || isGestorTransferencia;
 
         const documentosRet: TransferenciaAnexoDto[] = documentosDB.map((d) => {
             const link = this.uploadService.getDownloadToken(d.arquivo.id, '30d').download_token;
@@ -1867,15 +1837,7 @@ export class TransferenciaService {
         dto: UpdateTransferenciaAnexoDto,
         user: PessoaFromJwt
     ) {
-        // Gestor de Distribuição de Recurso não pode atualizar documentos,
-        // a menos que também seja Gestor de Transferências (que tem precedência)
-        if (
-            user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']) &&
-            !user.hasSomeRoles(['CadastroTransferencia.editar', 'CadastroTransferencia.administrador'])
-        ) {
-            throw new HttpException('Você não tem permissão para atualizar documentos nesta transferência.', 403);
-        }
-
+        // O acesso a este endpoint já é controlado pelo @Roles(['CadastroTransferenciaAnexo.editar']) no controller.
         this.uploadService.checkUploadOrDownloadToken(dto.upload_token);
         if (dto.diretorio_caminho)
             await this.uploadService.updateDir({ caminho: dto.diretorio_caminho }, dto.upload_token);
@@ -1902,15 +1864,7 @@ export class TransferenciaService {
     }
 
     async remove_document(transferenciaId: number, transferenciaAnexoId: number, user: PessoaFromJwt) {
-        // Gestor de Distribuição de Recurso não pode remover documentos,
-        // a menos que também seja Gestor de Transferências (que tem precedência)
-        if (
-            user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso']) &&
-            !user.hasSomeRoles(['CadastroTransferencia.editar', 'CadastroTransferencia.administrador'])
-        ) {
-            throw new HttpException('Você não tem permissão para remover documentos nesta transferência.', 403);
-        }
-
+        // O acesso a este endpoint já é controlado pelo @Roles(['CadastroTransferenciaAnexo.remover']) no controller.
         await this.prisma.transferenciaAnexo.updateMany({
             where: { transferencia_id: transferenciaId, removido_em: null, id: transferenciaAnexoId },
             data: {

--- a/backend/src/common/ListaDePrivilegios.ts
+++ b/backend/src/common/ListaDePrivilegios.ts
@@ -282,6 +282,7 @@ export type ListaDePrivilegios =
     | 'CadastroClassificacao.listar'
     | 'SMAE.liberar_pdm_as_ps'
     | 'SMAE.AtualizacaoEmLote'
+    | 'SMAE.PerfilGestorDistribuicaoRecurso'
     | 'Menu.AtualizacaoEmLote.MDO'
     | 'Menu.metas'
     | 'Menu.meta.pdm'

--- a/backend/src/common/ListaDePrivilegios.ts
+++ b/backend/src/common/ListaDePrivilegios.ts
@@ -168,7 +168,6 @@ export type ListaDePrivilegios =
     | 'CadastroWorkflows.editar'
     | 'CadastroWorkflows.remover'
     | 'AndamentoWorkflow.listar'
-    | 'SMAE.gestor_distribuicao_recurso'
     | 'CadastroCronogramaTransferencia.inserir'
     | 'CadastroCronogramaTransferencia.listar'
     | 'CadastroCronogramaTransferencia.remover'

--- a/backend/src/common/ListaDePrivilegios.ts
+++ b/backend/src/common/ListaDePrivilegios.ts
@@ -182,6 +182,8 @@ export type ListaDePrivilegios =
     | 'Reports.remover.Projetos'
     | 'Reports.executar.CasaCivil'
     | 'Reports.remover.CasaCivil'
+    | 'Reports.executar.CasaCivilGestorDistRec'
+    | 'Reports.remover.CasaCivilGestorDistRec'
     | 'Reports.executar.ProgramaDeMetas'
     | 'Reports.remover.ProgramaDeMetas'
     | 'CadastroEquipamentoMDO.inserir'

--- a/backend/src/common/consts.ts
+++ b/backend/src/common/consts.ts
@@ -10,11 +10,12 @@ export const CONST_COD_NOTA_DIST_RECURSO = 'Aviso de distribuição de recurso';
 export const CONST_COD_NOTA_TRANSF_GOV = 'Transfere Gov';
 export const CONST_PERFIL_PARTICIPANTE_EQUIPE = 'Participante em equipes';
 export const CONST_PERFIL_COORDENADOR_EQUIPE = 'Coordenador em equipes';
-// não mude essa string sem atualizar o seed!
-export const CONST_PERFIL_CASA_CIVIL = 'Gestor(a) Transferências Voluntárias';
 
+// não mude essas strings sem atualizar o seed pare remover!
+export const CONST_PERFIL_CASA_CIVIL = 'Gestor(a) Transferências Voluntárias';
 export const CONST_PERFIL_COLAB_OBRA_NO_ORGAO = 'Colaborador(a) de obra no órgão';
 export const CONST_PERFIL_GESTOR_OBRA = 'Gestor(a) da Obra';
+export const CONST_PERFIL_GESTOR_DIST_RECURSO = 'Gestor(a) de Distribuição de Recurso';
 
 export const CONST_PERFIL_PARTICIPANTE_EQUIPE_PDM = '<PDM>Participante em equipes'; // deprecated
 export const LISTA_PRIV_ADMIN: ListaDePrivilegios[] = ['SMAE.superadmin'];

--- a/backend/src/pessoa/pessoa.service.ts
+++ b/backend/src/pessoa/pessoa.service.ts
@@ -251,6 +251,8 @@ export class PessoaService implements OnModuleInit {
         if (user.hasSomeRoles(['SMAE.superadmin']) == false) {
             await this.verificarPerfilNaoContemAdmin(createPessoaDto.perfil_acesso_ids);
         }
+
+        await this.verificarPerfisCompativeis(createPessoaDto.perfil_acesso_ids);
     }
 
     private async verificarPrivilegiosEdicao(id: number, updatePessoaDto: UpdatePessoaDto, user: PessoaFromJwt) {
@@ -284,6 +286,8 @@ export class PessoaService implements OnModuleInit {
                 await this.verificarPerfilNaoContemAdmin(updatePessoaDto.perfil_acesso_ids);
             }
         }
+
+        await this.verificarPerfisCompativeis(updatePessoaDto.perfil_acesso_ids);
 
         const pessoaCurrentOrgao = await this.prisma.pessoaFisica.findFirst({
             where: {
@@ -367,6 +371,44 @@ export class PessoaService implements OnModuleInit {
                 'O seu usuário não pode adicionar ou remover permissões de outros usuários que são administradores do sistema, ou adicionar a permissão de administrador para um usuário já existente.',
                 400
             );
+    }
+
+    /**
+     * Rejeita combinações de perfis cujos privilégios efetivos sejam conflitantes.
+     *
+     * `CadastroDistribuicaoSolicitacaoAjuste.inserir` é exclusivo do perfil restrito
+     * "Gestor(a) de Distribuição de Recurso" (sem acesso de edição às transferências).
+     * `CadastroTransferencia.editar` só vem de perfis amplos (Gestor de TVs/Administrador).
+     * A coexistência indica combinação errada na atribuição de perfis.
+     */
+    private async verificarPerfisCompativeis(perfil_acesso_ids: number[] | undefined) {
+        if (!perfil_acesso_ids || perfil_acesso_ids.length === 0) return;
+
+        const rows = await this.prisma.perfilAcesso.findMany({
+            where: { id: { in: perfil_acesso_ids } },
+            select: {
+                perfil_privilegio: {
+                    select: { privilegio: { select: { codigo: true } } },
+                },
+            },
+        });
+
+        const privilegios = new Set<string>();
+        for (const r of rows) {
+            for (const pp of r.perfil_privilegio) {
+                privilegios.add(pp.privilegio.codigo);
+            }
+        }
+
+        if (
+            privilegios.has('CadastroDistribuicaoSolicitacaoAjuste.inserir') &&
+            privilegios.has('CadastroTransferencia.editar')
+        ) {
+            throw new HttpException(
+                'O perfil de Gestor(a) de Distribuição de Recurso não pode ser combinado com perfis que possuem CadastroTransferencia.editar (Gestor de Transferências Voluntárias ou Administrador). Esses perfis têm escopos conflitantes.',
+                400
+            );
+        }
     }
 
     private verificarCPFObrigatorio(dto: CreatePessoaDto | UpdatePessoaDto) {

--- a/backend/src/pessoa/pessoa.service.ts
+++ b/backend/src/pessoa/pessoa.service.ts
@@ -1960,6 +1960,19 @@ export class PessoaService implements OnModuleInit {
             ret.privilegios.push('Menu.demandas');
         }
 
+        // Privilégio virtual que identifica o perfil restrito "Gestor(a) de Distribuição de Recurso".
+        // A posse de CadastroDistribuicaoSolicitacaoAjuste.inserir é exclusiva desse perfil —
+        // verificarPerfisCompativeis() rejeita combinações com CadastroTransferencia.editar
+        // (e administradores carregam .editar transitivamente). O `!administrador` cobre
+        // eventuais cadastros legados antes da validação. Frontend deve checar este priv
+        // único em vez de duplicar a regra composta.
+        if (
+            ret.privilegios.includes('CadastroDistribuicaoSolicitacaoAjuste.inserir') &&
+            !ret.privilegios.includes('CadastroTransferencia.administrador')
+        ) {
+            ret.privilegios.push('SMAE.PerfilGestorDistribuicaoRecurso');
+        }
+
         return ret;
     }
 

--- a/backend/src/pp/tarefa/tarefa.service.ts
+++ b/backend/src/pp/tarefa/tarefa.service.ts
@@ -439,15 +439,6 @@ export class TarefaService {
                 };
             }
 
-            // Caso seja Gestor de distribuição de recurso
-            // Por mais que tenha o mesmo órgão que a tarefa, não pode editar.
-            if (user.hasSomeRoles(['SMAE.gestor_distribuicao_recurso'])) {
-                return {
-                    pode_editar: false,
-                    pode_editar_realizado: false,
-                };
-            }
-
             // TODO passar o tipo do projeto da cá, pra conseguir liberar o acesso total de editação
             // para quem é do MDO, não há nenhum
 

--- a/backend/src/reports/demandas/demandas.controller.ts
+++ b/backend/src/reports/demandas/demandas.controller.ts
@@ -14,7 +14,7 @@ export class DemandasController {
 
     @Post('')
     @ApiBearerAuth('access-token')
-    @Roles(['Reports.executar.CasaCivil'])
+    @Roles(['Reports.executar.CasaCivil', 'Reports.executar.CasaCivilGestorDistRec'])
     async create(@Body() dto: CreateRelDemandasDto, @CurrentUser() user: PessoaFromJwt): Promise<DemandasRelatorioDto> {
         return await this.demandasService.asJSON(dto, user);
     }

--- a/backend/src/reports/demandas/demandas.service.ts
+++ b/backend/src/reports/demandas/demandas.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { Date2YMD } from 'src/common/date2ymd';
 import { CsvWriterOptions, WriteCsvToFile } from 'src/common/helpers/CsvWriter';
 import { PessoaFromJwt } from 'src/auth/models/PessoaFromJwt';
@@ -56,6 +56,14 @@ export class DemandasService implements ReportableService {
     constructor(private readonly prisma: PrismaService) {}
 
     async asJSON(dto: CreateRelDemandasDto, user: PessoaFromJwt | null = null): Promise<DemandasRelatorioDto> {
+        // Defesa em profundidade: o endpoint síncrono POST /relatorio/demandas não passa
+        // por saveReport, então a coerção de orgao_id para o perfil restrito de
+        // Gestor(a) de Distribuição de Recurso precisa ser repetida aqui.
+        if (user?.hasSomeRoles(['SMAE.PerfilGestorDistribuicaoRecurso'])) {
+            if (!user.orgao_id) throw new BadRequestException('Usuário sem órgão associado.');
+            dto.orgao_id = user.orgao_id;
+        }
+
         const whereCond = await this.buildFilteredWhereStr(dto, user);
         const out_demandas: RelDemandasDto[] = [];
         const out_enderecos: RelDemandasEnderecosDto[] = [];

--- a/backend/src/reports/relatorios/reports.controller.ts
+++ b/backend/src/reports/relatorios/reports.controller.ts
@@ -23,6 +23,7 @@ export class ReportsController {
     @ApiBearerAuth('access-token')
     @Roles([
         'Reports.executar.CasaCivil',
+        'Reports.executar.CasaCivilGestorDistRec',
         'Reports.executar.PDM',
         'Reports.executar.Projetos',
         'Reports.executar.MDO',
@@ -43,6 +44,7 @@ export class ReportsController {
     @Get()
     @Roles([
         'Reports.executar.CasaCivil',
+        'Reports.executar.CasaCivilGestorDistRec',
         'Reports.executar.PDM',
         'Reports.executar.Projetos',
         'Reports.executar.MDO',
@@ -61,6 +63,7 @@ export class ReportsController {
     @ApiBearerAuth('access-token')
     @Roles([
         'Reports.remover.CasaCivil',
+        'Reports.remover.CasaCivilGestorDistRec',
         'Reports.remover.PDM',
         'Reports.remover.Projetos',
         'Reports.remover.MDO',

--- a/backend/src/reports/relatorios/reports.service.ts
+++ b/backend/src/reports/relatorios/reports.service.ts
@@ -1,5 +1,6 @@
 import {
     BadRequestException,
+    ForbiddenException,
     forwardRef,
     HttpException,
     Inject,
@@ -402,6 +403,23 @@ export class ReportsService {
             parametros.orgao_id = user.orgao_id;
         }
 
+        // Privilégio escopado `Reports.executar.CasaCivilGestorDistRec` só libera fonte=Demandas.
+        // Se o usuário só tem o escopado (sem o `Reports.executar.CasaCivil` amplo), bloqueia
+        // outras fontes do módulo CasaCivil que o decorator @Roles deixou passar.
+        const fontesCasaCivilNaoDemandas: FonteRelatorio[] = [
+            FonteRelatorio.Parlamentares,
+            FonteRelatorio.TribunalDeContas,
+            FonteRelatorio.Transferencias,
+            FonteRelatorio.AtvPendentes,
+        ];
+        if (
+            user &&
+            fontesCasaCivilNaoDemandas.includes(dto.fonte) &&
+            !user.hasSomeRoles(['Reports.executar.CasaCivil'])
+        ) {
+            throw new ForbiddenException('Usuário não tem permissão para executar este relatório.');
+        }
+
         console.log(parametros);
         return await this.prisma.$transaction(async (prismaTx: Prisma.TransactionClient) => {
             const result = await prismaTx.relatorio.create({
@@ -511,10 +529,21 @@ export class ReportsService {
             ipp = decodedPageToken.ipp;
         }
 
+        // Se o usuário só tem o privilégio escopado de CasaCivil (Demandas), força o filtro
+        // para que ele não enxergue relatórios de outras fontes do módulo, mesmo via filtro
+        // explícito ou registros legados.
+        let fonteFilter: FonteRelatorio | undefined = filters.fonte;
+        if (
+            user.hasSomeRoles(['Reports.executar.CasaCivilGestorDistRec']) &&
+            !user.hasSomeRoles(['Reports.executar.CasaCivil'])
+        ) {
+            fonteFilter = FonteRelatorio.Demandas;
+        }
+
         const rows = await this.prisma.relatorio.findMany({
             where: {
                 id: filters.id,
-                fonte: filters.fonte,
+                fonte: fonteFilter,
                 pdm_id: filters.pdm_id,
                 removido_em: null,
                 sistema: { in: [sistema, 'SMAE'] },
@@ -646,6 +675,27 @@ export class ReportsService {
     }
 
     async delete(id: number, user: PessoaFromJwt) {
+        // Privilégio escopado `Reports.remover.CasaCivilGestorDistRec` só libera remoção de
+        // fonte=Demandas. Se o usuário só tem o escopado (sem o `Reports.remover.CasaCivil`),
+        // bloqueia outras fontes CasaCivil que o decorator @Roles deixou passar.
+        const fontesCasaCivilNaoDemandas: FonteRelatorio[] = [
+            FonteRelatorio.Parlamentares,
+            FonteRelatorio.TribunalDeContas,
+            FonteRelatorio.Transferencias,
+            FonteRelatorio.AtvPendentes,
+        ];
+        const relatorio = await this.prisma.relatorio.findFirst({
+            where: { id, removido_em: null },
+            select: { fonte: true },
+        });
+        if (
+            relatorio &&
+            fontesCasaCivilNaoDemandas.includes(relatorio.fonte) &&
+            !user.hasSomeRoles(['Reports.remover.CasaCivil'])
+        ) {
+            throw new ForbiddenException('Usuário não tem permissão para remover este relatório.');
+        }
+
         await this.prisma.relatorio.updateMany({
             where: {
                 id: id,

--- a/backend/src/reports/relatorios/reports.service.ts
+++ b/backend/src/reports/relatorios/reports.service.ts
@@ -394,6 +394,14 @@ export class ReportsService {
         if (dto.fonte === 'Orcamento' || dto.fonte === 'PrevisaoCusto') {
             if (Array.isArray(parametros.orgaos) && parametros.orgaos.length === 0) delete parametros.orgaos;
         }
+
+        // Trava de órgão para o perfil restrito "Gestor(a) de Distribuição de Recurso":
+        // força o filtro no momento da criação para que persista na task e no JSON da relatorio.
+        if (dto.fonte === 'Demandas' && user?.hasSomeRoles(['SMAE.PerfilGestorDistribuicaoRecurso'])) {
+            if (!user.orgao_id) throw new BadRequestException('Usuário sem órgão associado.');
+            parametros.orgao_id = user.orgao_id;
+        }
+
         console.log(parametros);
         return await this.prisma.$transaction(async (prismaTx: Prisma.TransactionClient) => {
             const result = await prismaTx.relatorio.create({


### PR DESCRIPTION
## Contexto

`SMAE.gestor_distribuicao_recurso` era usado como flag "anti-access": detectado em ~13 pontos do backend para BLOQUEAR ações, em vez do padrão aditivo do resto do sistema (privilégios CONCEDEM acesso, não removem).

Com o PR #621 (workflow `CadastroDistribuicaoSolicitacaoAjuste.*` já em homol), o gestor passou a ter um caminho aditivo legítimo (criar solicitações de ajuste). As travas subtrativas viraram redundantes — os controllers já protegem via `@Roles('CadastroTransferencia.editar')` que o gestor não tem.

Esta PR também resolve **SERI/S03.05** (relatório de Demandas para o perfil) e **SERI/S03.10** (Resumo / Monitoramento / Vínculos somente leitura) aproveitando a refatoração.

## O que muda

### Backend — limpeza do anti-flag
- **9 checks subtrativos removidos** em `transferencia.service.ts`, `distribuicao-recurso.service.ts`, `distribuicao-recurso-status.service.ts`, `tarefa.service.ts`, `nota.service.ts`. Em todos os casos, o `@Roles()` do controller já garante a proteção (verificado caso a caso).
- **4 cálculos de `pode_editar` simplificados** — agora baseados puramente em `CadastroTransferencia.editar`/`administrador`, sem a parte negativa do flag.
- **Limpeza do privilégio**: removido de `ListaDePrivilegios.ts`, de `PrivConfig` e do perfil "Gestor(a) de Distribuição de Recurso" no seed. O cleanup da tabela `privilegio` cai natural via `atualizar_modulos_e_privilegios()`, que já faz `deleteMany({ codigo: { notIn: todosPrivilegios } })`.

### Backend — novo privilégio virtual
- **`SMAE.PerfilGestorDistribuicaoRecurso`** (novo, em `ListaDePrivilegios.ts`) — injetado dinamicamente em `pessoa.service.ts` ao construir o JWT, no mesmo bloco onde já existem `Menu.cc_consulta_geral`, `Menu.demandas` etc. A regra: tem `CadastroDistribuicaoSolicitacaoAjuste.inserir` && não tem `CadastroTransferencia.administrador`.
- O `!administrador` é failsafe para registros legados — `verificarPerfisCompativeis()` (ver abaixo) já bloqueia novos cadastros.
- **Sede única da regra**: três call sites que antes faziam a checagem composta passam a checar apenas o priv virtual:
  - `transferencia.service.ts` — scope-filter da listagem.
  - `reports/relatorios/reports.service.ts` — força `parametros.orgao_id` no save de Demandas.
  - `reports/demandas/demandas.service.ts` — defesa em profundidade no endpoint síncrono.
- Frontend passa a checar **um único priv** ao invés de duplicar a regra composta.

### Backend — validação no cadastro de Pessoa
- **Nova `verificarPerfisCompativeis()` em `pessoa.service.ts`** — erro 400 ao tentar salvar pessoa cuja união de privilégios contenha `CadastroDistribuicaoSolicitacaoAjuste.inserir` + `CadastroTransferencia.editar` simultaneamente. Mensagem clara identificando que o perfil de Gestor de Distribuição não combina com perfis administradores.

### Backend — SERI/S03.05 (Relatório de Demandas)
- Novos privilégios escopados `Reports.executar.CasaCivilGestorDistRec` / `Reports.remover.CasaCivilGestorDistRec` adicionados ao seed e ao perfil "Gestor(a) de Distribuição de Recurso". Decisão de design: **não** dar o `Reports.executar.CasaCivil` amplo, que liberaria também Parlamentares / TribunalDeContas / Transferencias / AtvPendentes — só Demandas tem coerção de órgão.
- `reports.controller.ts` (POST/GET/DELETE) e `demandas.controller.ts` aceitam o priv escopado ao lado do amplo.
- `reports.service.ts`:
  - `saveReport()` força `parametros.orgao_id = user.orgao_id` para `fonte === 'Demandas'` quando o usuário tem o priv virtual `SMAE.PerfilGestorDistribuicaoRecurso`. Filtro **persiste** no `relatorio.parametros` e na task — o background job lê o valor já travado, sem depender de re-resolver o usuário.
  - `saveReport()` rejeita (403) fontes CasaCivil que não sejam Demandas quando o usuário só tem o priv escopado — failsafe caso uma fonte nova seja adicionada ao módulo no futuro.
  - `findAll()` força `fonte: Demandas` quando o usuário só tem o priv escopado, escondendo registros legados.
  - `delete()` checa a fonte do relatório antes de remover; bloqueia exclusão de outras fontes CasaCivil quando o usuário só tem o priv escopado.
- `DemandasService.asJSON()` repete a coerção de `orgao_id` como defesa em profundidade (o endpoint síncrono `POST /relatorio/demandas` não passa por `saveReport`).
- A trava existente em `buildFilteredWhereStr` baseada em `!CadastroDemanda.validar` continua intacta — ainda atende outros perfis sem `validar` que precisam de scoping.

### Backend — SERI/S03.10 (Resumo / Monitoramento / Vínculos, somente leitura)
- Adicionadas ao perfil no seed as três `listar` que faltavam para abrir as telas em modo consulta:
  - `CadastroTransferencia.listar` — habilita GET `/transferencia/:id` (Resumo) e `/:id/historico`.
  - `AndamentoWorkflow.listar` — habilita GET de andamento usado no Monitoramento.
  - `CadastroCronogramaTransferencia.listar` — habilita listagem de tarefas/cronograma no Monitoramento.
- Mutation endpoints (`PATCH`/`DELETE`) seguem gateados por `CadastroTransferencia.editar` / `CadastroVinculo.editar` etc. — privs que o perfil não tem, ou seja, somente leitura natural via `@Roles()`.
- Vínculos: GET já aceitava `CadastroVinculo.listar` (perfil já tinha). Mutations seguem bloqueadas.
- `transferencia.service.ts` (`permissionSet`, ~1168) escopa as transferências do gestor às que têm distribuição do seu órgão — aplicado tanto em `findAllTransferencia` quanto em `findOneTransferencia`. Sem leak de outras transferências.

### Frontend
Sem mudanças neste PR. Tarefas FE separadas:
- **S03.05**: travar select "Gestor Municipal" para `user.orgao_id` quando `hasPriv('SMAE.PerfilGestorDistribuicaoRecurso')`.
- **S03.10**: esconder botões "Editar", "Configurar workflow", "Excluir" e ações de movimentação de fluxo nas telas Resumo / Monitoramento / Vínculos quando `hasPriv('SMAE.PerfilGestorDistribuicaoRecurso')`. GET endpoints já liberados neste PR.

## Mudança de comportamento a observar

Scope filter da listagem de transferências teve uma diferença sutil:
- **Antes**: usuário com `flag` + `CadastroTransferencia.editar` → NÃO era escopado por órgão.
- **Depois**: usuário com `.inserir` + `CadastroTransferencia.editar` → É escopado por órgão.

A nova validação no save de pessoa torna essa combinação impossível para registros novos. Pessoas já existentes com essa combinação (provavelmente nenhuma — sempre foi configuração inválida) passariam a enxergar menos. Vale validar com `SELECT` antes do merge.

## Test plan
- [ ] `npx tsc --noEmit` no backend (zero erros novos — erros pré-existentes idênticos antes e depois).
- [ ] Rodar seed em staging e confirmar que o privilégio antigo (`SMAE.gestor_distribuicao_recurso`) sai sem quebrar perfis existentes e que o perfil ganha `Reports.executar.CasaCivilGestorDistRec` + `Reports.remover.CasaCivilGestorDistRec` + as três `listar` de S03.10.
- [ ] Query em homol: confirmar que nenhuma pessoa atual tem `CadastroDistribuicaoSolicitacaoAjuste.inserir` + `CadastroTransferencia.editar` simultaneamente.
- [ ] Login como gestor de distribuição:
  - Listagem de transferências mostra só do próprio órgão.
  - GET `/transferencia/:id` (Resumo), endpoints de Monitoramento (workflow andamento, cronograma/tarefas) e Vínculos respondem 200; `PATCH`/`DELETE` em distribuição/transferência/vínculo retornam 403.
  - Criar solicitação de ajuste continua funcionando.
  - JWT inclui `SMAE.PerfilGestorDistribuicaoRecurso`.
  - Acesso ao relatório de Demandas funciona; tentar mandar `orgao_id` diferente do próprio é silenciosamente sobrescrito (verificar `relatorio.parametros` no DB).
  - Tentar criar/deletar relatório de fonte CasaCivil ≠ Demandas (Parlamentares/TribunalDeContas/Transferencias/AtvPendentes) retorna 403.
  - `findAll` de relatórios não retorna registros de outras fontes CasaCivil mesmo se forem `Publico` ou criados anteriormente.
- [ ] Login como gestor de transferências (admin): comportamento inalterado; JWT NÃO inclui `SMAE.PerfilGestorDistribuicaoRecurso`.
- [ ] Tentar salvar pessoa combinando os dois perfis: erro 400 com mensagem clara.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Relocated permission enforcement from service methods to controller-level decorators for improved authorization architecture
  * Simplified edit-permission logic for transfers and resource distribution operations

* **Authorization & Access Control**
  * Granted Casa Civil report execution and removal permissions to distribution-resource managers
  * Added validation to prevent incompatible role combinations
  * Updated permission restrictions to use controller-based enforcement instead of inline service checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
