### PR TITLE
feat(envio-de-emails): add customizar assunto e corpo antes de enviar

### DIFF
--- a/frontend/src/router/configuracoes.js
+++ b/frontend/src/router/configuracoes.js
@@ -1203,6 +1203,15 @@ export default [
                   título: 'Envio de E-mails',
                 },
               },
+              {
+                name: 'envioDeEmails.detalhes',
+                path: 'detalhes',
+                component: () => import('@/views/envioDeEmails/EnvioDeEmailsDetalhes.vue'),
+                meta: {
+                  título: 'Detalhes do E-mail',
+                  rotaDeEscape: 'envioDeEmails.listar',
+                },
+              },
             ],
           },
         ],

--- a/frontend/src/stores/envioDeEmails.store.ts
+++ b/frontend/src/stores/envioDeEmails.store.ts
@@ -4,13 +4,17 @@ const baseUrl = `${import.meta.env.VITE_API_URL}`;
 
 interface EmailItem {
   id: number;
-  sigra: string;
-  descricao: string;
+  assunto: string;
+  nomes_parlamentares: string;
+  criado_em: string;
+  criado_por: { id: number; nome_exibicao: string };
 }
 
 interface Estado {
   lista: EmailItem[];
   paginacao: Paginacao;
+  assuntoUltimoEmail: string;
+  corpoUltimoEmail: string;
   chamadasPendentes: {
     lista: boolean;
     disparar: boolean;
@@ -31,6 +35,8 @@ export const useEnvioDeEmailsStore = defineStore('envioDeEmails', {
       temMais: false,
       totalRegistros: 0,
     },
+    assuntoUltimoEmail: '',
+    corpoUltimoEmail: '',
     chamadasPendentes: {
       lista: false,
       disparar: false,
@@ -67,6 +73,9 @@ export const useEnvioDeEmailsStore = defineStore('envioDeEmails', {
         };
 
         this.lista = linhas;
+        this.assuntoUltimoEmail = linhas[0]?.assunto ?? '';
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this.corpoUltimoEmail = (linhas[0] as any)?.corpo ?? '';
         this.paginacao.paginaCorrente = paginaCorrente;
         this.paginacao.paginas = paginas;
         this.paginacao.temMais = temMais;
@@ -79,12 +88,12 @@ export const useEnvioDeEmailsStore = defineStore('envioDeEmails', {
       }
     },
 
-    async dispararEmail(): Promise<boolean> {
+    async dispararEmail(assunto?: string, corpo?: string): Promise<boolean> {
       this.chamadasPendentes.disparar = true;
       this.erro.disparar = null;
 
       try {
-        await this.requestS.post(`${baseUrl}/demanda/enviar-email-parlamentares`, {});
+        await this.requestS.post(`${baseUrl}/demanda/enviar-email-parlamentares`, { assunto, corpo });
         return true;
       } catch (erro: unknown) {
         this.erro.disparar = erro;

--- a/frontend/src/stores/envioDeEmails.store.ts
+++ b/frontend/src/stores/envioDeEmails.store.ts
@@ -5,6 +5,7 @@ const baseUrl = `${import.meta.env.VITE_API_URL}`;
 interface EmailItem {
   id: number;
   assunto: string;
+  corpo: string | null;
   nomes_parlamentares: string;
   criado_em: string;
   criado_por: { id: number; nome_exibicao: string };
@@ -74,8 +75,7 @@ export const useEnvioDeEmailsStore = defineStore('envioDeEmails', {
 
         this.lista = linhas;
         this.assuntoUltimoEmail = linhas[0]?.assunto ?? '';
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        this.corpoUltimoEmail = (linhas[0] as any)?.corpo ?? '';
+        this.corpoUltimoEmail = linhas[0]?.corpo ?? '';
         this.paginacao.paginaCorrente = paginaCorrente;
         this.paginacao.paginas = paginas;
         this.paginacao.temMais = temMais;

--- a/frontend/src/views/envioDeEmails/EnvioDeEmailsDetalhes.vue
+++ b/frontend/src/views/envioDeEmails/EnvioDeEmailsDetalhes.vue
@@ -1,0 +1,90 @@
+<script setup>
+import { storeToRefs } from 'pinia';
+import { ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
+
+import { useAlertStore } from '@/stores/alert.store';
+import { useEnvioDeEmailsStore } from '@/stores/envioDeEmails.store';
+
+const router = useRouter();
+const alertStore = useAlertStore();
+const envioDeEmailsStore = useEnvioDeEmailsStore();
+const { assuntoUltimoEmail, corpoUltimoEmail, chamadasPendentes } = storeToRefs(envioDeEmailsStore);
+
+const preenchido = ref(false);
+const assunto = ref('');
+const corpo = ref('');
+
+watch(
+  [assuntoUltimoEmail, corpoUltimoEmail],
+  ([novoAssunto, novoCorpo]) => {
+    if (!preenchido.value) {
+      assunto.value = novoAssunto;
+      corpo.value = novoCorpo;
+      if (novoAssunto || novoCorpo) {
+        preenchido.value = true;
+      }
+    }
+  },
+  { immediate: true },
+);
+
+if (!envioDeEmailsStore.lista.length) {
+  envioDeEmailsStore.buscarTudo({ pagina: 1 });
+}
+
+function handleEnviar() {
+  alertStore.confirmAction('Deseja enviar o e-mail para os parlamentares?', async () => {
+    const ok = await envioDeEmailsStore.dispararEmail(assunto.value, corpo.value);
+    if (ok) {
+      router.push({ name: 'envioDeEmails.listar' });
+    }
+  });
+}
+</script>
+
+<template>
+  <CabecalhoDePagina />
+
+  <form
+    class="mt2"
+    @submit.prevent="handleEnviar"
+  >
+    <div class="mb2">
+      <SmaeLabel
+        for="assunto"
+        label="Assunto"
+      />
+      <input
+        id="assunto"
+        v-model="assunto"
+        class="inputtext light big"
+        type="text"
+      >
+    </div>
+
+    <div class="mb2">
+      <SmaeLabel
+        for="corpo"
+        label="Conteúdo"
+      />
+      <textarea
+        id="corpo"
+        v-model="corpo"
+        class="inputtext light big"
+        rows="20"
+      />
+    </div>
+
+    <SmaeFieldsetSubmit
+      :disabled="chamadasPendentes.disparar"
+    >
+      <button
+        class="btn big"
+        type="submit"
+      >
+        Enviar
+      </button>
+    </SmaeFieldsetSubmit>
+  </form>
+</template>

--- a/frontend/src/views/envioDeEmails/EnvioDeEmailsDetalhes.vue
+++ b/frontend/src/views/envioDeEmails/EnvioDeEmailsDetalhes.vue
@@ -29,9 +29,7 @@ watch(
   { immediate: true },
 );
 
-if (!envioDeEmailsStore.lista.length) {
-  envioDeEmailsStore.buscarTudo({ pagina: 1 });
-}
+envioDeEmailsStore.buscarTudo({ pagina: 1 });
 
 function handleEnviar() {
   alertStore.confirmAction('Deseja enviar o e-mail para os parlamentares?', async () => {

--- a/frontend/src/views/envioDeEmails/EnvioDeEmailsLista.vue
+++ b/frontend/src/views/envioDeEmails/EnvioDeEmailsLista.vue
@@ -39,11 +39,6 @@ function buscarDados() {
   });
 }
 
-async function handleEnviarEmail() {
-  await envioDeEmailsStore.dispararEmail();
-  buscarDados();
-}
-
 watch(
   () => [
     route.query?.pagina,
@@ -61,13 +56,12 @@ watch(
 <template>
   <CabecalhoDePagina>
     <template #acoes>
-      <button
+      <router-link
+        :to="{ name: 'envioDeEmails.detalhes' }"
         class="btn big"
-        type="button"
-        @click="handleEnviarEmail"
       >
         Enviar e-mail
-      </button>
+      </router-link>
     </template>
   </CabecalhoDePagina>
 


### PR DESCRIPTION
Adiciona página de detalhes do e-mail onde o usuário edita assunto e conteúdo pré-preenchidos com o último envio antes de confirmar o disparo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated email composition page with Subject and Message fields, prefilled from the latest email when available.
  * Sending now asks for confirmation, disables the send button while pending, and returns to the list on success.
  * The email list action now navigates to the composition page instead of sending directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->