### PR TITLE
fix: Migalhas de metas não exibem o último item

### DIFF
--- a/frontend/src/components/metas/MigalhasDeMetas.vue
+++ b/frontend/src/components/metas/MigalhasDeMetas.vue
@@ -1,4 +1,4 @@
-<script lang="ts" setup>
+<script lang="js" setup>
 import { storeToRefs } from 'pinia';
 import { computed, watchEffect } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
@@ -37,24 +37,143 @@ const atividadeId = computed(() => {
   return Number.isNaN(id) ? undefined : id;
 });
 
-const rotasComplementares = computed(() => {
-  if (!Array.isArray(route.meta.migalhasDeMetas) || route.meta.migalhasDeMetas?.length === 0) {
-    return [];
+function rotaCorrenteCoincide(caminho) {
+  return route.path === caminho
+    || route.path === String(caminho).replace(/\/$/, '');
+}
+
+function compilarTextoDoLink(meta, name, limite) {
+  return truncate(
+    (meta?.tituloMigalhaDeMeta && (
+      typeof meta.tituloMigalhaDeMeta === 'function'
+        ? meta.tituloMigalhaDeMeta(route)
+        : meta.tituloMigalhaDeMeta
+    ))
+    || meta?.títuloParaMenu
+    || (meta?.título && (
+      typeof meta.título === 'function'
+        ? meta.título()
+        : meta.título
+    ))
+    || name,
+    limite,
+  );
+}
+
+const listaDeMigalhas = computed(() => {
+  const migalhas = [];
+  // vamos conferir se a rota corrente já está presente nas migalhas de pão.
+  // Caso não esteja, adicionamos ao final, sem link
+  let rotaCorrentePresenteNaMigalha = false;
+
+  // Dentro de Planos Setoriais, os caminhos das rotas de metas
+  // são prefixados com `/plano-setorial/$ID}` direto no componente `<SmaeLink>`.
+  // Precisamos levar isso em consideração para verificar se
+  // a rota corrente já está presente nas migalhas ou não.
+  const prefixoDeCaminhos = route.meta?.prefixoDosCaminhos ?? '';
+
+  // As primeiras rotas estão definidas manualmente por arquitetura legada da versão original
+  if (activePdm.value?.id) {
+    migalhas.push({
+      to: '/metas',
+      textoDoItem: activePdm.value?.nome,
+      desabilitar: !metaId.value || !activePdm.value?.id,
+    });
   }
 
-  return route.meta.migalhasDeMetas.map((x) => {
+  if (metaId.value && activePdm.value?.id) {
+    Object.values(rotasDosNiveisDeMetas).forEach((item) => {
+      const possuiNivel = activePdm.value?.[`possui_${item.nível}`];
+      const nivelDaMeta = singleMeta.value?.[item.nível];
+
+      if (
+        possuiNivel
+        && nivelDaMeta
+        && [item.nível, 'todas'].includes(groupBy)
+      ) {
+        const rotuloNivel = activePdm.value?.[`rotulo_${item.nível}`];
+        const desabilitar = rotaCorrenteCoincide(`${prefixoDeCaminhos}/metas/${item.segmento}/${nivelDaMeta?.id}`);
+        rotaCorrentePresenteNaMigalha ||= desabilitar;
+        migalhas.push({
+          to: `/metas/${item.segmento}/${nivelDaMeta?.id}`,
+          textoDoItem: `${rotuloNivel} ${nivelDaMeta?.descricao}`,
+          desabilitar,
+        });
+      }
+    });
+  }
+
+  if (metaId.value && singleMeta.value.id) {
+    const desabilitar = rotaCorrenteCoincide(`${prefixoDeCaminhos}/metas/${metaId.value}`);
+    rotaCorrentePresenteNaMigalha ||= desabilitar;
+    migalhas.push({
+      to: `/metas/${metaId.value}`,
+      textoDoItem: `${singleMeta.value?.codigo} ${singleMeta.value?.titulo}`,
+      desabilitar,
+    });
+  }
+
+  if (iniciativaId.value && activePdm.value?.possui_iniciativa && singleIniciativa.value.id) {
+    const desabilitar = rotaCorrenteCoincide(`${prefixoDeCaminhos}/metas/${metaId.value}/iniciativas/${iniciativaId.value}`);
+    rotaCorrentePresenteNaMigalha ||= desabilitar;
+    migalhas.push({
+      to: `/metas/${metaId.value}/iniciativas/${iniciativaId.value}`,
+      textoDoItem: `${activePdm.value?.rotulo_iniciativa} ${singleIniciativa.value?.codigo} ${singleIniciativa.value?.titulo}`,
+      desabilitar,
+    });
+  }
+
+  if (atividadeId.value && activePdm.value?.possui_atividade && singleAtividade.value.id) {
+    const desabilitar = rotaCorrenteCoincide(`${prefixoDeCaminhos}/metas/${metaId.value}/iniciativas/${iniciativaId.value}/atividades/${atividadeId.value}`);
+    rotaCorrentePresenteNaMigalha ||= desabilitar;
+    migalhas.push({
+      to: `/metas/${metaId.value}/iniciativas/${iniciativaId.value}/atividades/${atividadeId.value}`,
+      textoDoItem: `${activePdm.value?.rotulo_atividade} ${singleAtividade.value?.codigo} ${singleAtividade.value?.titulo}`,
+      desabilitar,
+    });
+  }
+
+  // Adicionar rotas extras que podem ter sido definidas por metadados da rota corrente
+  route.meta.migalhasDeMetas?.forEach((x) => {
     let rotaParaResolver = x;
+    let desabilitar;
 
     if (typeof x === 'string') {
-      if (x.indexOf('/') > -1) {
+      if (x.includes('/')) {
+        if (rotaCorrenteCoincide(x)) {
+          rotaCorrentePresenteNaMigalha = true;
+          desabilitar = true;
+        }
         rotaParaResolver = { path: x };
       } else {
+        if (x === route.name) {
+          rotaCorrentePresenteNaMigalha = true;
+          desabilitar = true;
+        }
         rotaParaResolver = { name: x };
       }
     }
 
-    return router.resolve({ ...rotaParaResolver, params: route.params });
+    const item = router.resolve({ ...rotaParaResolver, params: route.params });
+
+    migalhas.push({
+      to: item.href,
+      textoDoItem: compilarTextoDoLink(item.meta, item.name, 50),
+      desabilitar,
+    });
   });
+
+  if (!rotaCorrentePresenteNaMigalha) {
+    migalhas.push({
+      // Não sei o motivo de o carte aqui ser em 150 caracteres,
+      // mas é o que estava sendo usado antes.
+      // Talvez seja para evitar que títulos muito longos quebrem a linha.
+      textoDoItem: compilarTextoDoLink(route.meta, route.name, 150),
+      desabilitar: true,
+    });
+  }
+
+  return migalhas;
 });
 
 watchEffect(() => {
@@ -87,126 +206,20 @@ watchEffect(() => {
   <nav class="migalhas-de-pão migalhas-de-pão--metas">
     <ul class="migalhas-de-pão__lista">
       <li
-        v-if="activePdm?.id"
+        v-for="(item, index) in listaDeMigalhas"
+        :key="`rota-migalha--${index}`"
         class="migalhas-de-pão__item"
       >
         <SmaeLink
-          v-if="metaId && activePdm?.id"
+          v-if="!item.desabilitar && item.to"
+          :to="item.to"
           class="migalhas-de-pão__link"
-          to="/metas"
         >
-          {{ activePdm?.nome }}
+          {{ item.textoDoItem }}
         </SmaeLink>
         <template v-else>
-          {{ activePdm?.nome }}
+          {{ item.textoDoItem }}
         </template>
-      </li>
-      <template v-if="metaId && activePdm?.id">
-        <template
-          v-for="item in Object.values(rotasDosNiveisDeMetas)"
-          :key="item.nível"
-        >
-          <li
-            v-if="activePdm['possui_' + item.nível]
-              && singleMeta[item.nível]
-              && [item.nível, 'todas'].includes(groupBy)
-            "
-            class="migalhas-de-pão__item"
-          >
-            <SmaeLink
-              :to="`/metas/${item.segmento}/${singleMeta[item.nível]?.id}`"
-              class="migalhas-de-pão__link"
-            >
-              {{ activePdm['rotulo_' + item.nível] }} {{ singleMeta[item.nível]?.descricao }}
-            </SmaeLink>
-          </li>
-        </template>
-      </template>
-      <li
-        v-if="metaId && singleMeta.id"
-        class="migalhas-de-pão__item"
-      >
-        <SmaeLink
-          :to="`/metas/${metaId}`"
-          class="migalhas-de-pão__link"
-        >
-          {{ singleMeta?.codigo }} {{ singleMeta?.titulo }}
-        </SmaeLink>
-      </li>
-
-      <li
-        v-if="iniciativaId && activePdm?.possui_iniciativa && singleIniciativa.id"
-        class="migalhas-de-pão__item"
-      >
-        <SmaeLink
-          :to="`/metas/${metaId}/iniciativas/${iniciativaId}`"
-          class="migalhas-de-pão__link"
-        >
-          {{ activePdm?.rotulo_iniciativa }}
-          {{ singleIniciativa?.codigo }}
-          {{ singleIniciativa?.titulo }}
-        </SmaeLink>
-      </li>
-
-      <li
-        v-if="atividadeId && activePdm?.possui_atividade && singleAtividade.id"
-        class="migalhas-de-pão__item"
-      >
-        <SmaeLink
-          :to="`/metas/${metaId}/iniciativas/${iniciativaId}/atividades/${atividadeId}`"
-          class="migalhas-de-pão__link"
-        >
-          {{ activePdm?.rotulo_atividade }}
-          {{ singleAtividade?.codigo }}
-          {{ singleAtividade?.titulo }}
-        </SmaeLink>
-      </li>
-
-      <li
-        v-for="(item, itemIndex) in rotasComplementares"
-        :key="`rota-complementar--${itemIndex}`"
-        class="migalhas-de-pão__item migalhas-de-pão__link"
-      >
-        <RouterLink :to="item.href">
-          {{
-            truncate(
-              item.meta?.tituloMigalhaDeMeta && (
-                typeof item.meta.tituloMigalhaDeMeta === 'function' ?
-                  item.meta.tituloMigalhaDeMeta($route)
-                  : item.meta.tituloMigalhaDeMeta
-              )
-                || item.meta?.títuloParaMenu
-                || item.meta.título && (
-                  typeof item.meta.título === 'function' ?
-                    item.meta.título()
-                    : item.meta.título
-                )
-                || item.name
-              , 50)
-          }}
-        </RouterLink>
-      </li>
-
-      <li
-        v-if="$route.meta.tituloMigalhaDeMeta"
-        class="migalhas-de-pão__item"
-      >
-        {{
-          truncate(
-            $route.meta.tituloMigalhaDeMeta && (
-              typeof $route.meta.tituloMigalhaDeMeta === 'function' ?
-                $route.meta.tituloMigalhaDeMeta($route)
-                : $route.meta.tituloMigalhaDeMeta
-            )
-              || $route.meta?.títuloParaMenu
-              || $route.meta.título && (
-                typeof $route.meta.título === 'function' ?
-                  $route.meta.título()
-                  : $route.meta.título
-              )
-              || $route.name
-            , 150)
-        }}
       </li>
     </ul>
   </nav>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved breadcrumb navigation: breadcrumbs now more reliably reflect the current page context across the meta/iniciativa/atividade hierarchy.
  * Enhanced title resolution for breadcrumb labels with better fallbacks and support for route path prefixing.
  * Breadcrumb items are rendered more consistently, including handling of additional breadcrumb targets and proper disabling when they match the current route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->