### PR TITLE
fix(reports.post-process): declara o dialeto do CSV em vez de deixar o DuckDB inferir

### DIFF
--- a/backend/src/reports/post-process/csv-schema.provider.ts
+++ b/backend/src/reports/post-process/csv-schema.provider.ts
@@ -25,6 +25,10 @@ function quoteLiteral(value: string): string {
  * Usa `read_csv(..., columns={...})` em vez de `read_csv_auto`, o que garante que
  * DECIMAL não seja inferido como DOUBLE (perda de precisão em valores monetários) e
  * que identificadores como `0001.02` permaneçam VARCHAR em vez de virarem número.
+ *
+ * Além dos tipos, o **dialeto** (aspa, escape, quebra de linha) também é declarado — ver o
+ * comentário em `load()`. Tipo declarado com dialeto adivinhado ainda deixava o conteúdo das
+ * células à mercê de uma amostragem do arquivo.
  */
 export class CsvSchemaProvider extends BaseDataSourceProvider {
     readonly name = 'csv-schema';
@@ -53,6 +57,19 @@ export class CsvSchemaProvider extends BaseDataSourceProvider {
             .map((c) => `${quoteLiteral(c.name)}: ${quoteLiteral(c.type)}`)
             .join(', ');
 
+        // Dialeto declarado por inteiro, não inferido.
+        //
+        // Mesmo com `columns` explícito, o DuckDB ainda deduz aspas/escape/quebra de linha a
+        // partir de uma amostra do arquivo — e amostra é função dos dados. Um CSV cujo texto
+        // contenha muitos apóstrofos pode levar o detector a eleger `'` como aspa, e aí um
+        // campo perfeitamente válido passa a ser lido torto. Como quem escreve estes arquivos
+        // é o próprio SMAE (json2csv com `DefaultCsvOptions`, ou o `CsvFileHandler`), o
+        // dialeto é conhecido de antemão: não há motivo para adivinhar.
+        //
+        // O que isto NÃO resolve — medido, para não virar falsa sensação de segurança: arquivo
+        // com terminador de registro **misto** (cabeçalho `\r\n` e linhas `\n`) continua sendo
+        // aceito ou rejeitado conforme os dados, porque `new_line` é conferido no cabeçalho.
+        // Contra isso o que vale é o writer emitir EOL consistente.
         const sql = `CREATE OR REPLACE TABLE ${quoteIdent(table)} AS
             SELECT * FROM read_csv(
                 ${quoteLiteral(this.csvPath)},
@@ -60,7 +77,10 @@ export class CsvSchemaProvider extends BaseDataSourceProvider {
                 header = true,
                 columns = {${columns}},
                 nullstr = '',
-                all_varchar = false
+                all_varchar = false,
+                new_line = '\\r\\n',
+                quote = '"',
+                escape = '"'
             )`;
 
         await context.connection.run(sql);

--- a/backend/src/reports/post-process/report-post-process.service.spec.ts
+++ b/backend/src/reports/post-process/report-post-process.service.spec.ts
@@ -29,17 +29,19 @@ const SCHEMA: ReportFileSchema = {
     ],
 };
 
-// CSV bruto usa vírgula (delimitador padrão do json2csv); ';' é só na saída.
+// CSV bruto usa vírgula (delimitador padrão do json2csv) e CRLF (o `eol` de
+// `DefaultCsvOptions`); ';' é só na saída. As fixtures reproduzem os bytes que os
+// writers do SMAE realmente emitem — o leitor declara o dialeto e não o adivinha.
 const CSV_BRUTO = [
     'id,valor,vigencia,dotacao,orgao__sigla',
     '1,1234.56,2024-10-15,2024.10.15.3350,SMUL',
     '2,99.90,2024-01-02,0001.02,SEHAB',
     '3,,,,SMUL',
-].join('\n');
+].join('\r\n');
 
 function escreverCsvBruto(): string {
     const p = path.join(os.tmpdir(), `spec-raw-${process.pid}-${Math.random().toString(36).slice(2)}.csv`);
-    fs.writeFileSync(p, CSV_BRUTO + '\n');
+    fs.writeFileSync(p, CSV_BRUTO + '\r\n');
     return p;
 }
 
@@ -86,6 +88,34 @@ describe('ReportPostProcessService', () => {
         const xlsx = out.find((f) => f.name.endsWith('.xlsx'))!;
         return { out, ignoradas, csvTexto: fs.readFileSync(csv.localFile!, 'utf-8'), xlsxPath: xlsx.localFile! };
     }
+
+    it('não deixa o apóstrofo do texto virar aspa de campo', async () => {
+        // Regressão: sem `quote`/`escape` declarados, o detector de dialeto do DuckDB elege a
+        // aspa a partir de uma amostra do arquivo. Num CSV cujos valores estejam entre
+        // apóstrofos — `'0001.02'` numa dotação, uma citação numa descrição — ele conclui que
+        // a aspa é `'` e **remove os apóstrofos do dado**, silenciosamente. Medido: o mesmo
+        // arquivo lê `0001.02` com o detector e `'0001.02'` com o dialeto declarado.
+        const bruto = path.join(os.tmpdir(), `spec-apos-${process.pid}-${Math.random().toString(36).slice(2)}.csv`);
+        criados.push(bruto);
+        fs.writeFileSync(
+            bruto,
+            'id,valor,vigencia,dotacao,orgao__sigla\r\n' +
+                "1,1.00,2024-01-01,'0001.02','SMUL'\r\n" +
+                "2,2.00,2024-01-02,'0002.03','SEHAB'\r\n"
+        );
+
+        const { arquivos: out } = await service.aplicarModelo([{ name: 'exemplo.csv', localFile: bruto }], [SCHEMA], {
+            arquivos: [{ arquivo: 'exemplo.csv' }],
+        });
+        for (const f of out) if (f.localFile) criados.push(f.localFile);
+
+        const csvTexto = fs.readFileSync(out.find((f) => f.name.endsWith('.csv'))!.localFile!, 'utf-8');
+        expect(csvTexto).toContain("'SMUL'");
+        expect(csvTexto).toContain("'SEHAB'");
+        // A dotação tem o guard do Excel, então vem como `="'0001.02'"` com as aspas dobradas.
+        expect(csvTexto).toContain('0001.02');
+        expect(csvTexto).not.toMatch(/;SMUL;|;SMUL$|;SMUL\r/m);
+    });
 
     it('emite CSV e XLSX a partir do mesmo CSV bruto', async () => {
         const { out } = await aplicar({ arquivos: [{ arquivo: 'exemplo.csv' }] });
@@ -174,7 +204,7 @@ describe('ReportPostProcessService', () => {
     it('preserva a precisão de DECIMAL (read_csv_auto inferiria DOUBLE)', async () => {
         const bruto = path.join(os.tmpdir(), `spec-dec-${process.pid}.csv`);
         criados.push(bruto);
-        fs.writeFileSync(bruto, 'id,valor,vigencia,dotacao,orgao__sigla\n1,0.10,2024-01-01,x,Y\n');
+        fs.writeFileSync(bruto, 'id,valor,vigencia,dotacao,orgao__sigla\r\n1,0.10,2024-01-01,x,Y\r\n');
 
         const { arquivos: out } = await service.aplicarModelo([{ name: 'exemplo.csv', localFile: bruto }], [SCHEMA], {
             arquivos: [{ arquivo: 'exemplo.csv', colunas: [{ coluna: 'valor' }] }],


### PR DESCRIPTION
## ⚠️ Mudanças de saída (breaking changes)

Nenhuma. Rodei os **18 relatórios** contra um dump de homol restaurado, com e sem este commit: os **52 CSVs saem byte a byte idênticos**. A mudança só remove adivinhação do leitor.

## O problema

O `read_csv` do `CsvSchemaProvider` já recebia `columns` e `delim`, mas **aspa, escape e quebra de linha continuavam sendo deduzidos** de uma amostra do arquivo. Amostra é função dos dados — ou seja, o comportamento do leitor variava com o conteúdo do relatório.

Não é teórico. Num CSV cujos valores estejam entre apóstrofos — `'0001.02'` numa dotação, uma citação numa descrição — o detector conclui que a aspa do arquivo é `'` e **remove os apóstrofos do dado**, sem erro nenhum. Medido no mesmo arquivo, mesma chamada, só mudando o dialeto:

```
detector (hoje)   -> ["1","0001.02","SMUL"]
dialeto declarado -> ["1","'0001.02'","'SMUL'"]
```

Corrupção silenciosa: o relatório sai, com o dado errado.

## A correção

`new_line`, `quote` e `escape` explícitos. Quem escreve esses arquivos é o próprio SMAE (json2csv com `DefaultCsvOptions`, ou o `CsvFileHandler`), então o dialeto é conhecido de antemão — não há o que inferir.

As fixtures do spec passam a usar **CRLF**, que é o `eol` real do `DefaultCsvOptions`. Antes usavam LF e não representavam os bytes de produção — por isso o teste nunca teria pego isto.

## Teste de regressão

`não deixa o apóstrofo do texto virar aspa de campo` — verificado que **falha sem o fix** e passa com ele.

## O que isto NÃO resolve

Arquivo com terminador de registro **misto** (cabeçalho `\r\n` e linhas `\n`) continua sendo aceito ou rejeitado conforme os dados, porque `new_line` é conferido no cabeçalho. Medido: `origens.csv` (CRLF=2, LF=5 fora de aspas) passa dos dois jeitos; `projetos.csv` falha dos dois jeitos. Contra EOL misto o que vale é o writer emitir quebra consistente — foi o que o #648 fez no `CsvFileHandler`.

Registro isso explicitamente porque a recomendação original prometia "nenhum relatório poderia ser derrubado pelo EOL do writer", e **medindo, não é verdade**.

## Efeito colateral a considerar no review

Um writer que passasse a emitir LF puro deixaria de ser lido (hoje o detector aceitaria). Como o pós-processamento tem falha segura, o relatório sairia **cru** em vez de quebrar. Auditei os 18 relatórios: os **51 CSVs brutos não vazios usam CRLF exclusivamente** (contando terminadores fora de aspas), então nenhum produtor atual é afetado.

## Verificação

- `tsc --noEmit` limpo; `jest src/reports/post-process` verde (52 no branch isolado; 364 com os 11 PRs da série mergeados).
- 18/18 relatórios executados contra banco real, todos com `pp=true`, saída idêntica à de antes deste commit.