### PR TITLE
fix(busca): suporte a acentuação e novos campos na busca por palavra-chave

### DIFF
--- a/backend/prisma/manual-copy/0009a-f_transfere_gov_oportunidade_update_tsvector.pgsql
+++ b/backend/prisma/manual-copy/0009a-f_transfere_gov_oportunidade_update_tsvector.pgsql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION f_transfere_gov_oportunidade_update_tsvector() RETURNS TRIGGER AS $$
 BEGIN
     NEW.vetores_busca = (
-        SELECT to_tsvector('simple',
+        SELECT to_tsvector('simple_unaccent',
             COALESCE(CAST(NEW.tipo AS TEXT), '') || ' ' ||
             COALESCE(CAST(NEW.avaliacao AS TEXT), '') || ' ' ||
             COALESCE(CAST(NEW.id_programa AS TEXT), '') || ' ' ||
@@ -35,3 +35,7 @@ EXCEPTION
    WHEN duplicate_object THEN
       NULL;
 END;$$;
+
+-- Reconstrói os vetores de busca de todas as oportunidades já existentes, para que
+-- a mudança de configuração de busca acima passe a valer também nos registros já existentes.
+UPDATE transfere_gov_oportunidade SET vetores_busca = NULL;

--- a/backend/prisma/manual-copy/0032-trigger.parlamentar.pgsql
+++ b/backend/prisma/manual-copy/0032-trigger.parlamentar.pgsql
@@ -7,7 +7,7 @@ BEGIN
     NEW.vetores_busca = COALESCE((
         SELECT
             to_tsvector(
-                'simple',
+                'simple_unaccent',
                 COALESCE(NEW.nome, '') || ' ' ||
                 COALESCE(NEW.nome_popular, '') || ' ' ||
                 COALESCE(

--- a/backend/prisma/manual-copy/0054-f_rebuild_transferencia_tsvector.pgsql
+++ b/backend/prisma/manual-copy/0054-f_rebuild_transferencia_tsvector.pgsql
@@ -8,7 +8,7 @@ DECLARE
 BEGIN
     SELECT
         to_tsvector(
-            'simple',
+            'simple_unaccent',
             COALESCE(CAST(t_main.esfera AS TEXT), '') || ' ' ||
             COALESCE(CAST(t_main.interface AS TEXT), '') || ' ' ||
             COALESCE(CAST(t_main.ano AS TEXT), '') || ' ' ||
@@ -19,6 +19,7 @@ BEGIN
             COALESCE(t_main.objeto, ' ') || ' ' ||
             COALESCE(t_main.demanda, ' ') || ' ' ||
             COALESCE(t_main.plano_de_acao, ' ') || ' ' ||
+            COALESCE(t_main.observacoes, ' ') || ' ' ||
             COALESCE(tt.nome, ' ') || ' ' ||
             COALESCE(o1.sigla, ' ') || ' ' ||
             COALESCE(o1.descricao, ' ') || ' ' ||

--- a/backend/prisma/migrations/20260727170000_vetores_busca_unaccent/migration.sql
+++ b/backend/prisma/migrations/20260727170000_vetores_busca_unaccent/migration.sql
@@ -1,0 +1,44 @@
+-- Adiciona suporte a acentuação na busca por palavra-chave (full-text search).
+-- A extensão unaccent + a config simple_unaccent normalizam os acentos antes de
+-- aplicar a config 'simple', permitindo que buscas com e sem acento casem.
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+DO
+$$BEGIN
+    CREATE TEXT SEARCH CONFIGURATION simple_unaccent (COPY = simple);
+EXCEPTION
+    WHEN duplicate_object THEN
+        NULL;
+END;$$;
+
+ALTER TEXT SEARCH CONFIGURATION simple_unaccent
+    ALTER MAPPING FOR asciiword, asciihword, hword_asciipart, word, hword, hword_part, numword, numhword, hword_numpart
+    WITH unaccent, simple;
+
+-- projeto e variavel possuem vetores_busca como coluna GENERATED ALWAYS, então a
+-- expressão não pode ser alterada in-place: é preciso remover e recriar a coluna
+-- (o ADD COLUMN GENERATED recomputa todas as linhas existentes).
+ALTER TABLE "projeto" DROP COLUMN "vetores_busca";
+ALTER TABLE "projeto" ADD COLUMN "vetores_busca" tsvector GENERATED ALWAYS AS (
+    to_tsvector('simple_unaccent',
+        COALESCE("nome", '') || ' '
+     || COALESCE("codigo", '') || ' '
+     || COALESCE(REPLACE("codigo", '.', ' '), '') || ' '
+     || COALESCE("mdo_detalhamento", '') || ' '
+     || COALESCE("mdo_observacoes", '') || ' '
+     || COALESCE("mdo_programa_habitacional", '') || ' '
+     || COALESCE("secretario_responsavel", '') || ' '
+     || COALESCE("secretario_executivo", '') || ' '
+     || COALESCE("secretario_colaborador", '')
+    )
+) STORED;
+
+ALTER TABLE "variavel" DROP COLUMN "vetores_busca";
+ALTER TABLE "variavel" ADD COLUMN "vetores_busca" tsvector GENERATED ALWAYS AS (
+    to_tsvector('simple_unaccent',
+        COALESCE("titulo", '') || ' '
+     || COALESCE("descricao", '') || ' '
+     || COALESCE("codigo", '') || ' '
+     || COALESCE(REPLACE(REPLACE("codigo", '/', ' '), '.', ' '), '')
+    )
+) STORED;

--- a/backend/prisma/migrations/20260727170000_vetores_busca_unaccent/migration.sql
+++ b/backend/prisma/migrations/20260727170000_vetores_busca_unaccent/migration.sql
@@ -17,7 +17,10 @@ ALTER TEXT SEARCH CONFIGURATION simple_unaccent
 
 -- projeto e variavel possuem vetores_busca como coluna GENERATED ALWAYS, então a
 -- expressão não pode ser alterada in-place: é preciso remover e recriar a coluna
--- (o ADD COLUMN GENERATED recomputa todas as linhas existentes).
+-- (o ADD COLUMN GENERATED recomputa todas as linhas existentes). Nenhuma das duas
+-- colunas tem índice dependente (confirmado: sem GIN em projeto/variavel.vetores_busca),
+-- mas o DROP+ADD ainda adquire ACCESS EXCLUSIVE e reescreve a tabela — rodar em janela
+-- de baixo tráfego se o volume de linhas for grande em produção.
 ALTER TABLE "projeto" DROP COLUMN "vetores_busca";
 ALTER TABLE "projeto" ADD COLUMN "vetores_busca" tsvector GENERATED ALWAYS AS (
     to_tsvector('simple_unaccent',

--- a/backend/src/casa-civil/transferencia/transferencia.service.ts
+++ b/backend/src/casa-civil/transferencia/transferencia.service.ts
@@ -1362,20 +1362,33 @@ export class TransferenciaService {
             return token.replace(/\.(?=\d{3}(?:\D|$))/g, '');
         };
 
-        // Prefixo "R$" explícito
-        const comPrefixo = palavraChave.match(/R\$\s*([\d.,]+)/i)?.[1];
-        if (comPrefixo) return normalizaValorMonetario(comPrefixo);
+        const candidato = (() => {
+            // Prefixo "R$" explícito
+            const comPrefixo = palavraChave.match(/R\$\s*([\d.,]+)/i)?.[1];
+            if (comPrefixo) return normalizaValorMonetario(comPrefixo);
 
-        // Formato BR com separador de milhar e/ou decimal por vírgula
-        // (ex: "150.000", "150.000,00", "150000,00")
-        const comSeparadorOuVirgula = palavraChave.match(
-            /\b\d{1,3}(?:\.\d{3})+(?:,\d{1,2})?\b|\b\d+,\d{1,2}\b/
-        )?.[0];
-        if (comSeparadorOuVirgula) return normalizaValorMonetario(comSeparadorOuVirgula);
+            // Formato BR com separador de milhar e/ou decimal por vírgula
+            // (ex: "150.000", "150.000,00", "150000,00")
+            const comSeparadorOuVirgula = palavraChave.match(
+                /\b\d{1,3}(?:\.\d{3})+(?:,\d{1,2})?\b|\b\d+,\d{1,2}\b/
+            )?.[0];
+            if (comSeparadorOuVirgula) return normalizaValorMonetario(comSeparadorOuVirgula);
 
-        // Formato "simples": decimal com ponto (ex: "150000.55") ou número inteiro solto,
-        // exigindo ao menos 3 dígitos (ex: busca só "150000").
-        return palavraChave.match(/\b\d{3,}(?:\.\d{1,2})?\b/)?.[0];
+            // Formato "simples": decimal com ponto (ex: "150000.55") ou número inteiro solto,
+            // exigindo ao menos 3 dígitos (ex: busca só "150000"). Exige que o token não esteja
+            // colado em '.', '/' ou '-' para não capturar um trecho de Processo SEI formatado
+            // (ex: "00000000.000000/0000-00" não deve virar valor = 0).
+            return palavraChave.match(/(?:^|[^\d./-])(\d{3,}(?:\.\d{1,2})?)(?=$|[^\d./-])/)?.[1];
+        })();
+        if (candidato === undefined) return undefined;
+
+        // transferencia.valor é Decimal(15,2): no máximo 13 dígitos na parte inteira.
+        // Um candidato maior (ex: um número de SEI de 16 dígitos sem pontuação) estouraria
+        // a coluna e derrubaria a query inteira com "numeric field overflow".
+        const parteInteira = candidato.split('.')[0];
+        if (parteInteira.length > 13) return undefined;
+
+        return candidato;
     }
 
     /**

--- a/backend/src/casa-civil/transferencia/transferencia.service.ts
+++ b/backend/src/casa-civil/transferencia/transferencia.service.ts
@@ -1357,20 +1357,20 @@ export class TransferenciaService {
         const normalizaValorMonetario = (token: string): string => {
             if (token.includes(',')) {
                 // Formato BR: '.' é separador de milhar, ',' é separador decimal.
-                return token.replace(/\./g, '').replace(',', '.');
+                return token.replaceAll('.', '').replace(',', '.');
             }
             return token.replace(/\.(?=\d{3}(?:\D|$))/g, '');
         };
 
         const candidato = (() => {
             // Prefixo "R$" explícito
-            const comPrefixo = palavraChave.match(/R\$\s*([\d.,]+)/i)?.[1];
+            const comPrefixo = /R\$\s*([\d.,]+)/i.exec(palavraChave)?.[1];
             if (comPrefixo) return normalizaValorMonetario(comPrefixo);
 
             // Formato BR com separador de milhar e/ou decimal por vírgula
             // (ex: "150.000", "150.000,00", "150000,00")
-            const comSeparadorOuVirgula = palavraChave.match(
-                /\b\d{1,3}(?:\.\d{3})+(?:,\d{1,2})?\b|\b\d+,\d{1,2}\b/
+            const comSeparadorOuVirgula = /\b\d{1,3}(?:\.\d{3})+(?:,\d{1,2})?\b|\b\d+,\d{1,2}\b/.exec(
+                palavraChave
             )?.[0];
             if (comSeparadorOuVirgula) return normalizaValorMonetario(comSeparadorOuVirgula);
 
@@ -1378,7 +1378,7 @@ export class TransferenciaService {
             // exigindo ao menos 3 dígitos (ex: busca só "150000"). Exige que o token não esteja
             // colado em '.', '/' ou '-' para não capturar um trecho de Processo SEI formatado
             // (ex: "00000000.000000/0000-00" não deve virar valor = 0).
-            return palavraChave.match(/(?:^|[^\d./-])(\d{3,}(?:\.\d{1,2})?)(?=$|[^\d./-])/)?.[1];
+            return /(?:^|[^\d./-])(\d{3,}(?:\.\d{1,2})?)(?=$|[^\d./-])/.exec(palavraChave)?.[1];
         })();
         if (candidato === undefined) return undefined;
 

--- a/backend/src/casa-civil/transferencia/transferencia.service.ts
+++ b/backend/src/casa-civil/transferencia/transferencia.service.ts
@@ -1311,6 +1311,32 @@ export class TransferenciaService {
             }
         }
 
+        // Valor de Repasse (transferencia.valor) é um Decimal e não entra no tsvector.
+        // Detecta um token monetário no termo de busca e compara por igualdade exata.
+        const valorRepasse = this.extractValorRepasse(palavraChave);
+        if (valorRepasse !== undefined) {
+            searchConditions.push({ valor: valorRepasse });
+        }
+
+        // Processo SEI é armazenado só com dígitos (ver DistribuicaoRecursoService), então
+        // normalizamos o termo de busca da mesma forma e buscamos por substring.
+        const processoSeiDigits = this.extractProcessoSeiDigits(palavraChave);
+        if (processoSeiDigits !== undefined) {
+            searchConditions.push({
+                distribuicao_recursos: {
+                    some: {
+                        removido_em: null,
+                        registros_sei: {
+                            some: {
+                                removido_em: null,
+                                processo_sei: { contains: processoSeiDigits },
+                            },
+                        },
+                    },
+                },
+            });
+        }
+
         // Adiciona busca por palavras-chave (vetores).
         // Inclui mesmo quando o array está vazio: { id: { in: [] } } não casa com nada,
         // garantindo que a busca sem resultados não seja ignorada.
@@ -1319,6 +1345,51 @@ export class TransferenciaService {
         }
 
         return searchConditions.length > 0 ? searchConditions : undefined;
+    }
+
+    /**
+     * Detecta um valor monetário no termo de busca (ex: "R$ 150.000,00", "150000,00", "150000.55")
+     * e o normaliza para uma string decimal compatível com o campo transferencia.valor.
+     */
+    private extractValorRepasse(palavraChave: string): string | undefined {
+        // Como a coluna é Decimal(15,2), um '.' seguido de 3 dígitos nunca é parte decimal
+        // (moeda só tem até 2 casas) — é sempre separador de milhar (ex: "150.000").
+        const normalizaValorMonetario = (token: string): string => {
+            if (token.includes(',')) {
+                // Formato BR: '.' é separador de milhar, ',' é separador decimal.
+                return token.replace(/\./g, '').replace(',', '.');
+            }
+            return token.replace(/\.(?=\d{3}(?:\D|$))/g, '');
+        };
+
+        // Prefixo "R$" explícito
+        const comPrefixo = palavraChave.match(/R\$\s*([\d.,]+)/i)?.[1];
+        if (comPrefixo) return normalizaValorMonetario(comPrefixo);
+
+        // Formato BR com separador de milhar e/ou decimal por vírgula
+        // (ex: "150.000", "150.000,00", "150000,00")
+        const comSeparadorOuVirgula = palavraChave.match(
+            /\b\d{1,3}(?:\.\d{3})+(?:,\d{1,2})?\b|\b\d+,\d{1,2}\b/
+        )?.[0];
+        if (comSeparadorOuVirgula) return normalizaValorMonetario(comSeparadorOuVirgula);
+
+        // Formato "simples": decimal com ponto (ex: "150000.55") ou número inteiro solto,
+        // exigindo ao menos 3 dígitos (ex: busca só "150000").
+        return palavraChave.match(/\b\d{3,}(?:\.\d{1,2})?\b/)?.[0];
+    }
+
+    /**
+     * Detecta um trecho de Processo SEI no termo de busca e retorna só os dígitos,
+     * já que distribuicao_recurso_sei.processo_sei é gravado sem pontuação.
+     * Exige ao menos 8 dígitos para não colidir com identificador/ano/valor.
+     */
+    private extractProcessoSeiDigits(palavraChave: string): string | undefined {
+        const candidatos = palavraChave.match(/[\d./-]+/g) ?? [];
+        for (const candidato of candidatos) {
+            const digitos = candidato.replace(/\D/g, '');
+            if (digitos.length >= 8) return digitos;
+        }
+        return undefined;
     }
 
     async findOneTransferencia(id: number, user: PessoaFromJwt): Promise<TransferenciaDetailDto> {

--- a/backend/src/common/PrismaHelpers.ts
+++ b/backend/src/common/PrismaHelpers.ts
@@ -57,7 +57,7 @@ export class PrismaHelpers {
                 .join(' & ');
 
             const rows: { id: number }[] = await prisma.$queryRawUnsafe(
-                `SELECT id FROM ${tableName} WHERE vetores_busca @@ to_tsquery('simple', $1)`,
+                `SELECT id FROM ${tableName} WHERE vetores_busca @@ to_tsquery('simple_unaccent', $1)`,
                 words
             );
             palavrasChave = rows.map((row) => row.id);


### PR DESCRIPTION
## Resumo

- **Acentuação:** a busca por palavra-chave usava a config `'simple'` do Postgres full-text search, que não normaliza acentos — ex.: buscar "Sahao" não retornava "Beth Sahão". Adiciona a extensão `unaccent` + uma config `simple_unaccent` (COPY de `simple` com mapeamento `unaccent, simple`) e aplica em **todas** as tabelas com `vetores_busca`: `parlamentar`, `transferencia`, `transfere_gov_oportunidade`, `projeto`, `variavel`.
- **Novos campos na busca de Transferência:**
  - **Observação** (`transferencia.observacoes`) — entra no tsvector normalmente.
  - **Valor de Repasse** (`transferencia.valor`) — tratamento especial (como já existe para `identificador`): detecta um token monetário no termo de busca (`R$ 150.000,00`, `150000,00`, `150000.55`, `150000`) e faz match exato.
  - **Processo SEI** (`distribuicao_recurso_sei.processo_sei`) — tratamento especial: normaliza o termo para dígitos (o campo é gravado só com dígitos) e busca por substring, exigindo ≥8 dígitos para não colidir com identificador/ano/valor.

## Detalhes técnicos

- `projeto` e `variavel` têm `vetores_busca` como coluna `GENERATED ALWAYS`, então a migration faz `DROP`+`ADD COLUMN` (recomputa o vetor de todas as linhas na hora, usando `to_tsvector(regconfig, text)`, que é `IMMUTABLE`).
- `parlamentar`, `transferencia` e `transfere_gov_oportunidade` são atualizadas via trigger/função em `manual-copy/*.pgsql`; os 3 scripts foram ajustados para `simple_unaccent` e já reindexam o acervo existente (o de `transfere_gov_oportunidade` não reindexava antes — foi adicionado um `UPDATE ... SET vetores_busca = NULL` para isso).
- Único ponto de leitura (`PrismaHelpers.buscaIdsPalavraChave`) também trocado para `simple_unaccent`, cobrindo as 5 tabelas de uma vez.

## Test plan

- [x] `tsc --noEmit`: limpo (só erros pré-existentes em `test/`, não relacionados)
- [x] `jest` completo: 380/386 passando (as 6 falhas são pré-existentes em `Html2Text.spec.ts`, não relacionadas a esta mudança)
- [x] Migration + scripts `.pgsql` aplicados em banco de dev local sem erro
- [x] Testado diretamente no Postgres: parlamentares "Beth Sahao" e "Beth Sahão" agora casam buscando `sahao:*` **e** `sahão:*`
- [x] Colunas GENERATED de `projeto`/`variavel` recomputadas corretamente com `simple_unaccent`
- [x] Lógica de extração de Valor de Repasse e Processo SEI validada isoladamente com bateria de casos (BR, decimal simples, prefixo R$, SEI formatado/sem formatação)
- [ ] Validação manual na UI (recomendado antes do merge)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now matches text regardless of accents and diacritics.
  * Transfer searches can find records by exact monetary amount.
  * Added support for searching transfers by Processo SEI numbers.
  * Transfer search now includes observation text.
  * Existing search indexes were rebuilt to apply the improved matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->