### PR TITLE
feat(distribuicao-recurso): cancela planejamento de distribuição não contabilizada

### DIFF
--- a/backend/src/casa-civil/distribuicao-recurso/distribuicao-recurso-status.service.ts
+++ b/backend/src/casa-civil/distribuicao-recurso/distribuicao-recurso-status.service.ts
@@ -151,6 +151,31 @@ export class DistribuicaoRecursoStatusService {
                     },
                 });
 
+                let statusNovo;
+                if (dto.status_id) {
+                    statusNovo = await prismaTx.distribuicaoStatus.findFirstOrThrow({
+                        where: { id: dto.status_id },
+                        select: { tipo: true, valor_distribuicao_contabilizado: true },
+                    });
+                } else {
+                    statusNovo = await prismaTx.distribuicaoStatusBase.findFirstOrThrow({
+                        where: { id: dto.status_base_id },
+                        select: { tipo: true, valor_distribuicao_contabilizado: true },
+                    });
+                }
+
+                // Distribuição deixou de ser contabilizada (cancelada, redistribuída, impedida tecnicamente etc.):
+                // cancela todo o planejamento (fases/tarefas/cronograma) vinculado a ela.
+                if (statusNovo.valor_distribuicao_contabilizado === false) {
+                    await prismaTx.tarefa.updateMany({
+                        where: { distribuicao_recurso_id: distribuicao_id, removido_em: null },
+                        data: {
+                            removido_em: new Date(Date.now()),
+                            removido_por: user.id,
+                        },
+                    });
+                }
+
                 // Caso o status seja do tipo "ConcluidoComSucesso"
                 // Então é necessário atualizar a tarefa no cronograma.
                 if (distribuicaoRecursoStatus.distribuicao.transferencia.workflow_id) {
@@ -160,19 +185,6 @@ export class DistribuicaoRecursoStatusService {
                     );
 
                     if (workflowValido) {
-                        let statusNovo;
-                        if (dto.status_id) {
-                            statusNovo = await prismaTx.distribuicaoStatus.findFirstOrThrow({
-                                where: { id: dto.status_id },
-                                select: { tipo: true },
-                            });
-                        } else {
-                            statusNovo = await prismaTx.distribuicaoStatusBase.findFirstOrThrow({
-                                where: { id: dto.status_base_id },
-                                select: { tipo: true },
-                            });
-                        }
-
                         if (statusNovo.tipo == DistribuicaoStatusTipo.ConcluidoComSucesso) {
                             await prismaTx.tarefa.updateMany({
                                 where: { distribuicao_recurso_id: distribuicao_id },


### PR DESCRIPTION
## Contexto

No domínio de **Transferências Voluntárias**, cada *Distribuição de Recurso* pode ter planejamento próprio no cronograma (fases e tarefas). Quando o último registro do *Histórico de Status* passa a indicar `valor_distribuicao_contabilizado = false` (status do tipo Cancelada, Redirecionada/redistribuída, Impedida Tecnicamente etc.), a distribuição é desconsiderada para fins de contabilização e todo o planejamento vinculado a ela deve ser **cancelado**.

Antes, o cancelamento (soft-delete das tarefas) só ocorria para status do `tipo == Terminal`. Esta mudança generaliza a regra para **qualquer status com `valor_distribuicao_contabilizado = false`**.

## O que muda

`DistribuicaoRecursoStatusService.create()` (`backend/src/casa-civil/distribuicao-recurso/distribuicao-recurso-status.service.ts`):

- Busca a config do novo status (`tipo` + `valor_distribuicao_contabilizado`) uma única vez.
- Se `valor_distribuicao_contabilizado === false`, faz soft-delete (`removido_em` / `removido_por`) de **todas as `Tarefa` com `distribuicao_recurso_id`** da distribuição — que representam fases, tarefas e o cronograma da distribuição.
- Esse efeito roda independentemente da validade do workflow; os efeitos pré-existentes por `tipo` (`ConcluidoComSucesso`, `Terminal`) permanecem inalterados dentro do gate de workflow válido.

### Por que "fases + tarefas + cronograma" = linhas de `Tarefa`

As tarefas do cronograma de uma distribuição são geradas como linhas `Tarefa` com `distribuicao_recurso_id` (fases e tarefas do fluxo aparecem como `Tarefa` com `transferencia_fase_id` / `transferencia_tarefa_id`). O container `TarefaCronograma` e os modelos de runtime `TransferenciaAndamento` / `TransferenciaAndamentoTarefa` são **por transferência** (compartilhados entre distribuições) e por isso **não** são tocados.

## Escopo / decisões

- Apenas **backend**.
- **Sem restauração**: voltar a `contabilizado = true` não reativa o planejamento (unidirecional).
- **Sem backfill**: vale apenas para mudanças de status a partir do deploy.

## Como testar

1. Distribuição com tarefas/cronograma geradas (`Tarefa` com `distribuicao_recurso_id`, `removido_em = null`).
2. `POST distribuicao-recurso/:id/status` com um status de config `valor_distribuicao_contabilizado = false` (ex.: Cancelada / Impedida Tecnicamente).
3. Conferir no banco: as `Tarefa` da distribuição ficam com `removido_em`/`removido_por` preenchidos; as `Tarefa` de **outras** distribuições da mesma transferência permanecem intactas; `TarefaCronograma` e `TransferenciaAndamento(_Tarefa)` intactos.
4. Registrar depois um status `contabilizado = true` e confirmar que as tarefas **não** são restauradas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated distribution status processing to correctly account for whether the distribution value has been recorded.
  * Automatically cancels active related tasks when required by the selected status.
  * Preserved existing workflow handling for successfully completed and terminal statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->