### PR TITLE
fix(atualizacao-em-lote): corrige erros de edição em lote e resiliência do sistema de tasks

### DIFF
--- a/backend/src/atualizacao-em-lote/atualizacao-em-lote.service.ts
+++ b/backend/src/atualizacao-em-lote/atualizacao-em-lote.service.ts
@@ -1,9 +1,11 @@
 import { BadRequestException, forwardRef, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
 import { JwtService } from '@nestjs/jwt';
 import { Prisma, TipoAtualizacaoEmLote } from '@prisma/client';
 import { DateTime } from 'luxon';
 import { PessoaFromJwt } from 'src/auth/models/PessoaFromJwt';
 import { SYSTEM_TIMEZONE } from 'src/common/date2ymd';
+import { IsCrontabEnabled } from 'src/common/crontab-utils';
 import { PaginatedWithPagesDto, PAGINATION_TOKEN_TTL } from 'src/common/dto/paginated.dto';
 import { ListaDePrivilegios } from 'src/common/ListaDePrivilegios';
 import { PrismaService } from 'src/prisma/prisma.service';
@@ -46,6 +48,53 @@ export class AtualizacaoEmLoteService {
         @Inject(forwardRef(() => TaskService))
         private readonly taskService: TaskService
     ) {}
+
+    /**
+     * Reconciliação de lotes órfãos.
+     *
+     * Quando o job (task_queue) morre no meio da execução — tipicamente por OOM/SIGKILL — ele
+     * termina em status 'errored', mas a atualização em lote fica presa em 'Executando' para
+     * sempre, pois o `finalizarAtualizacaoEmLote` nunca roda. Este passo periódico detecta esses
+     * casos, marca o lote como 'Abortado' (estado que o enum reserva justamente para "morto no
+     * meio") e libera o buffer da task, evitando acúmulo de memória em disco.
+     */
+    @Interval(1000 * 60 * 10) // a cada 10 minutos
+    async reconciliaLotesOrfaos(): Promise<void> {
+        // Só reconcilia onde o worker de tasks roda (mesma família de crontab).
+        if (!IsCrontabEnabled('task')) return;
+
+        const orfaos = await this.prisma.atualizacaoEmLote.findMany({
+            where: {
+                status: 'Executando',
+                removido_em: null,
+                task: { status: 'errored' },
+            },
+            select: { id: true, task_id: true },
+        });
+
+        if (orfaos.length === 0) return;
+
+        this.logger.warn(
+            `Reconciliando ${orfaos.length} atualização(ões) em lote órfã(s): job morreu sem finalizar. Marcando como Abortado.`
+        );
+
+        for (const orfao of orfaos) {
+            try {
+                await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+                    await tx.atualizacaoEmLote.update({
+                        where: { id: orfao.id },
+                        data: { status: 'Abortado', terminou_em: new Date() },
+                    });
+
+                    if (orfao.task_id) {
+                        await tx.task_buffer.deleteMany({ where: { task_id: orfao.task_id } });
+                    }
+                });
+            } catch (error) {
+                this.logger.error(`Falha ao reconciliar atualização em lote ${orfao.id}: ${error}`);
+            }
+        }
+    }
 
     /**
      * Cria uma tarefa de atualização em lote e submete para processamento assíncrono

--- a/backend/src/bin/run-task.ts
+++ b/backend/src/bin/run-task.ts
@@ -15,6 +15,16 @@ process.on('unhandledRejection', async (reason: unknown) => {
     console.error('Rejeição não tratada:', reason);
 });
 
+// Se o processo-pai morrer (ex.: restart/deploy), o canal IPC do fork é fechado e este worker
+// fica órfão. Encerramos imediatamente: manter o worker vivo faria, junto com o re-pick por
+// timeout feito pelo novo pai, duas execuções concorrentes do mesmo job — duplicando efeitos
+// colaterais (ex.: tarefas). A transação da linha em andamento sofre rollback ao cair a conexão,
+// então a retomada reprocessa a linha com segurança.
+process.on('disconnect', () => {
+    console.error('Processo-pai desconectou; encerrando worker órfão para evitar execução concorrente.');
+    process.exit(1);
+});
+
 async function bootstrap() {
     // desliga os crontab do 'fork'
     process.env.DISABLED_CRONTABS = 'all';

--- a/backend/src/reports/relatorios/reports.service.ts
+++ b/backend/src/reports/relatorios/reports.service.ts
@@ -1201,8 +1201,6 @@ export class ReportsService {
                     sistema: true,
                     criado_em: true,
                     criado_por: true,
-                    progresso: true,
-                    processado_em: true,
                     criador: {
                         select: {
                             email: true,
@@ -1216,24 +1214,25 @@ export class ReportsService {
                 return;
             }
 
-            // Idempotência sob retry do job: se uma tentativa anterior já concluiu o relatório
-            // (progresso=100), não regerar o arquivo nem reenviar o e-mail. Fecha a janela em que o
-            // processo poderia morrer (ex.: OOM) logo após a transação de conclusão — que já enfileira
-            // o e-mail — mas antes de sinalizar sucesso ao processo-pai, o que dispararia um reprocessamento.
-            if (relatorio.progresso === 100 && relatorio.processado_em) {
-                this.logger.warn(
-                    `Relatório ${relatorio_id} já concluído por uma tentativa anterior; pulando reprocessamento.`
-                );
-                return;
-            }
-            await this.prisma.relatorio.update({
-                where: { id: relatorio_id },
+            // Reivindicação atômica contra reprocessamento por retry do job. Só prossegue se ainda
+            // não há arquivo gerado — `arquivo_id` é setado apenas na transação de conclusão
+            // bem-sucedida (updateRelatorioMetadata). Como o updateMany condicional é atômico, um
+            // relatório já concluído nunca é regerado nem tem o e-mail de conclusão reenviado, mesmo
+            // sob tentativas concorrentes. Um retry após crash (sem arquivo) segue normalmente.
+            const reivindicacao = await this.prisma.relatorio.updateMany({
+                where: { id: relatorio_id, arquivo_id: null },
                 data: {
                     iniciado_em: new Date(Date.now()),
                     err_msg: null,
                     progresso: 0,
                 },
             });
+            if (reivindicacao.count === 0) {
+                this.logger.warn(
+                    `Relatório ${relatorio_id} já concluído (arquivo existente); pulando reprocessamento.`
+                );
+                return;
+            }
 
             contexto = new ReportContext(this.prisma, relatorio.id, relatorio.sistema);
 

--- a/backend/src/reports/relatorios/reports.service.ts
+++ b/backend/src/reports/relatorios/reports.service.ts
@@ -1201,6 +1201,8 @@ export class ReportsService {
                     sistema: true,
                     criado_em: true,
                     criado_por: true,
+                    progresso: true,
+                    processado_em: true,
                     criador: {
                         select: {
                             email: true,
@@ -1211,6 +1213,17 @@ export class ReportsService {
             });
             if (!relatorio) {
                 this.logger.warn(`Relatório ${relatorio_id} não encontrado, completando job.`);
+                return;
+            }
+
+            // Idempotência sob retry do job: se uma tentativa anterior já concluiu o relatório
+            // (progresso=100), não regerar o arquivo nem reenviar o e-mail. Fecha a janela em que o
+            // processo poderia morrer (ex.: OOM) logo após a transação de conclusão — que já enfileira
+            // o e-mail — mas antes de sinalizar sucesso ao processo-pai, o que dispararia um reprocessamento.
+            if (relatorio.progresso === 100 && relatorio.processado_em) {
+                this.logger.warn(
+                    `Relatório ${relatorio_id} já concluído por uma tentativa anterior; pulando reprocessamento.`
+                );
                 return;
             }
             await this.prisma.relatorio.update({

--- a/backend/src/task/run_update/run-update.service.ts
+++ b/backend/src/task/run_update/run-update.service.ts
@@ -70,12 +70,17 @@ export class RunUpdateTaskService implements TaskableService {
         // 'Executando' está incluído propositalmente: se um job morrer no meio (ex.: OOM/SIGKILL)
         // após já ter marcado 'Executando', o retry precisa reencontrar o registro e retomar
         // (pulando os sucesso_ids) em vez de falhar com "não encontrada ou já processada".
-        const atualizacaoEmLote = await this.prisma.atualizacaoEmLote.findUnique({
+        //
+        // Porém, exige que a task associada NÃO esteja 'errored': se o reconciliador já deu o lote
+        // como perdido (marcando 'Abortado' e apagando o task_buffer), não se deve retomar. Durante
+        // uma execução/retry legítimo a task está 'running', então isso não bloqueia o fluxo normal.
+        const atualizacaoEmLote = await this.prisma.atualizacaoEmLote.findFirst({
             where: {
                 id: _params.atualizacao_em_lote_id,
                 status: {
                     in: ['Pendente', 'Executando', 'ConcluidoParcialmente', 'Falhou', 'Abortado', 'Concluido'],
                 },
+                task: { status: { not: 'errored' } },
             },
         });
         if (!atualizacaoEmLote) throw new Error('Atualização em lote não encontrada ou já processada');
@@ -201,7 +206,15 @@ export class RunUpdateTaskService implements TaskableService {
                                 // Por agora, a única entidade que é criada pela atualização em lote é a tarefa.
                                 // Então utilizando direto o serviço.
                                 // TODO?: Implementar interface para solução mais genérica.
-                                await this.tarefaService.create({ projeto_id: id }, paramsCriacaoTarefa.dto, pessoaJwt);
+                                // Passa a tx da linha: a criação da tarefa precisa ser atômica com o
+                                // resto da linha, senão um rollback deixaria tarefa órfã e um retry a
+                                // duplicaria.
+                                await this.tarefaService.create(
+                                    { projeto_id: id },
+                                    paramsCriacaoTarefa.dto,
+                                    pessoaJwt,
+                                    prismaTxn
+                                );
                             }
                         } catch (error) {
                             this.logger.error(`Erro ao atualizar ID ${id}: ${error.message}`);
@@ -231,6 +244,18 @@ export class RunUpdateTaskService implements TaskableService {
                         if (operacaoFalhou) {
                             throw new Error(`Rollback da transação para o ID ${id}`);
                         }
+
+                        // Marca o sucesso desta linha de forma transacional, junto com a própria
+                        // mutação. Assim, se o job morrer no meio e for retomado (status Executando),
+                        // as linhas já concluídas ficam persistidas em sucesso_ids e são puladas — o
+                        // que evita reprocessá-las e duplicar tarefas criadas por Add/CreateTarefa.
+                        await prismaTxn.atualizacaoEmLote.update({
+                            where: { id: _params.atualizacao_em_lote_id },
+                            data: {
+                                sucesso_ids: { push: id },
+                                n_sucesso: { increment: 1 },
+                            },
+                        });
                     });
 
                     n_sucesso++;

--- a/backend/src/task/run_update/run-update.service.ts
+++ b/backend/src/task/run_update/run-update.service.ts
@@ -66,12 +66,15 @@ export class RunUpdateTaskService implements TaskableService {
     async executeJob(_params: CreateRunUpdateDto, taskId: string, context: TaskContext): Promise<any> {
         this.logger.log(`Executando tarefa de atualização em lote. ID da tarefa: ${taskId}`);
 
-        // Apenas atualizações em lote pendentes.
+        // Estados a partir dos quais o job pode (re)executar/retomar.
+        // 'Executando' está incluído propositalmente: se um job morrer no meio (ex.: OOM/SIGKILL)
+        // após já ter marcado 'Executando', o retry precisa reencontrar o registro e retomar
+        // (pulando os sucesso_ids) em vez de falhar com "não encontrada ou já processada".
         const atualizacaoEmLote = await this.prisma.atualizacaoEmLote.findUnique({
             where: {
                 id: _params.atualizacao_em_lote_id,
                 status: {
-                    in: ['Pendente', 'ConcluidoParcialmente', 'Falhou', 'Abortado', 'Concluido'],
+                    in: ['Pendente', 'Executando', 'ConcluidoParcialmente', 'Falhou', 'Abortado', 'Concluido'],
                 },
             },
         });
@@ -120,12 +123,17 @@ export class RunUpdateTaskService implements TaskableService {
                         // Buscando título/nome da linha para logs.
                         const paramsBusca = this.preparaParamsParaFindOne(_params.tipo);
                         const registro = await service.findOne(paramsBusca.tipo, id, pessoaJwt, 'ReadWrite');
-                        // Armazena o registro no nosso log estendido
+                        // Armazena o registro no nosso log estendido.
+                        // IMPORTANTE: guardamos apenas o estado anterior das colunas afetadas,
+                        // e não o objeto completo do registro. Reter o objeto inteiro por linha
+                        // fazia o buffer crescer sem limite e estourava a memória (SIGKILL/OOM)
+                        // em lotes grandes. A "Versão Anterior" do relatório continua sendo gerada
+                        // a partir desse recorte enxuto.
                         const registroProcessamento: RegistroProcessamento = {
                             id: id,
                             nome: registro?.nome || registro?.titulo || registro?.descricao || 'Nome não identificado',
                             status: 'OK',
-                            registro: registro,
+                            registro: this.montaVersaoAnterior(registro, _params.ops),
                         };
 
                         // Adiciona aos registros processados
@@ -281,6 +289,21 @@ export class RunUpdateTaskService implements TaskableService {
         }
 
         return { success: true };
+    }
+
+    // Captura apenas o estado anterior das colunas que serão editadas, para a coluna
+    // "Versão Anterior" do relatório — sem reter o objeto completo do registro (evita OOM).
+    private montaVersaoAnterior(registro: any, ops: UpdateOperacaoDto[]): Record<string, any> {
+        const versaoAnterior: Record<string, any> = {};
+        if (!registro || typeof registro !== 'object') return versaoAnterior;
+
+        for (const op of ops) {
+            if (op.col in registro) {
+                versaoAnterior[op.col] = registro[op.col];
+            }
+        }
+
+        return versaoAnterior;
     }
 
     // Novo método para pré-processar as operações e adicionar operações implícitas

--- a/backend/src/task/run_update/run-update.service.ts
+++ b/backend/src/task/run_update/run-update.service.ts
@@ -141,7 +141,13 @@ export class RunUpdateTaskService implements TaskableService {
                             registro: this.montaVersaoAnterior(registro, _params.ops),
                         };
 
-                        // Adiciona aos registros processados
+                        // Adiciona aos registros processados, substituindo qualquer entrada anterior
+                        // deste mesmo id. Numa retomada, o stash carregado pode já conter o resultado
+                        // de uma tentativa anterior desta linha (ex.: falha reprocessada) — sem isso o
+                        // relatório final teria entradas duplicadas/conflitantes para o mesmo id.
+                        resultadosEstendidos.registrosProcessados = resultadosEstendidos.registrosProcessados.filter(
+                            (r) => r.id !== id
+                        );
                         resultadosEstendidos.registrosProcessados.push(registroProcessamento);
                         // Armazena dados após cada registro ser buscado
                         await context.stashData<LogResultadosEstendido>(resultadosEstendidos);
@@ -562,6 +568,10 @@ export class RunUpdateTaskService implements TaskableService {
     }
 
     private adicionarLogErro(error: any, id: number, nome: string, results_log: LogResultadosEstendido) {
+        // Remove qualquer falha anterior deste mesmo id (ex.: reprocessamento numa retomada),
+        // para não acumular entradas duplicadas de falha para o mesmo registro.
+        results_log.falhas = results_log.falhas.filter((f) => f.id !== id);
+
         if (error instanceof HttpException) {
             const errorResponse = this.extrairMensagemErro(error);
 

--- a/backend/src/task/task.service.ts
+++ b/backend/src/task/task.service.ts
@@ -663,6 +663,14 @@ export class TaskService {
             // contador local — do contrário n_retry ficaria preso em 1 e o retry nunca respeitaria
             // o limite de maxRetries (loop infinito).
             const nextRetryCount = currentRetryCount + 1;
+
+            // Limite de tentativas atingido: não agenda um novo retry (que só voltaria a 'pending'
+            // para errar de imediato no próximo pick). Propaga o erro para o handler externo marcar
+            // a task como 'errored'. Consistente com retryTimedOutTask.
+            if (nextRetryCount >= retryConfig.maxRetries) {
+                throw new Error(`Limite de tentativas excedido (${retryConfig.maxRetries}): ${lastError.message}`);
+            }
+
             const nextRetryTime = TaskRetryService.calculateNextRetryTime(nextRetryCount, retryConfig);
 
             this.logger.log(

--- a/backend/src/task/task.service.ts
+++ b/backend/src/task/task.service.ts
@@ -94,6 +94,18 @@ export class TaskRetryService {
     }
 }
 
+/**
+ * Sinaliza que o runJob já reagendou o retry da task (status voltou para 'pending' com esperar_ate).
+ * O chamador NÃO deve sobrescrever o status para 'errored' nesse caso, senão o handleCron nunca
+ * re-executa a task e ela fica presa.
+ */
+export class TaskRetryScheduledError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'TaskRetryScheduledError';
+    }
+}
+
 type InfoWorker = {
     pid: number;
     hostname: string;
@@ -488,23 +500,31 @@ export class TaskService {
                     this.current_concurrent_jobs--;
                 })
                 .catch(async (e: any) => {
-                    this.logger.error(`task ${task.id} failed`);
-                    this.logger.error(e);
+                    // Se o runJob já reagendou o retry (status = 'pending' com esperar_ate), NÃO
+                    // sobrescrever para 'errored' — do contrário o handleCron nunca re-executa a task.
+                    const retryAgendado = e instanceof TaskRetryScheduledError;
 
-                    await this.prisma.$transaction(async (prismaTx: Prisma.TransactionClient): Promise<void> => {
-                        await prismaTx.task_queue.update({
-                            where: { id: task.id },
-                            data: {
-                                status: 'errored',
-                                erro_em: new Date(),
-                                erro_mensagem: `${e}`,
-                            },
+                    if (retryAgendado) {
+                        this.logger.warn(`task ${task.id} falhou; ${e.message}`);
+                    } else {
+                        this.logger.error(`task ${task.id} failed`);
+                        this.logger.error(e);
+
+                        await this.prisma.$transaction(async (prismaTx: Prisma.TransactionClient): Promise<void> => {
+                            await prismaTx.task_queue.update({
+                                where: { id: task.id },
+                                data: {
+                                    status: 'errored',
+                                    erro_em: new Date(),
+                                    erro_mensagem: `${e}`,
+                                },
+                            });
+
+                            if (task.type == 'run_report') {
+                                await this.runReportService.handleError(task.id, e, prismaTx);
+                            }
                         });
-
-                        if (task.type == 'run_report') {
-                            await this.runReportService.handleError(task.id, e, prismaTx);
-                        }
-                    });
+                    }
 
                     if (task.pessoa_id) this.current_jobs_pessoa_ids.delete(task.pessoa_id);
                     if (task.type) this.current_jobs_types.delete(task.type);
@@ -574,7 +594,6 @@ export class TaskService {
 
     async runJob(taskId: number, type: task_type, params: Prisma.JsonValue, currentRetryCount: number): Promise<JSON> {
         let lastError: Error | null = null;
-        let retryCount = 0;
         const parsedParams = ParseParams(type, params);
         const retryConfig = parsedParams.retryConfig || new RetryConfigDto();
         try {
@@ -622,10 +641,11 @@ export class TaskService {
 
             if (!result) throw `process did not finished successfully, check logs`;
 
-            if (retryCount > 0) {
+            // Sucesso após uma ou mais tentativas: zera o contador e limpa o último erro registrado.
+            if (currentRetryCount > 0) {
                 await this.prisma.task_queue.update({
                     where: { id: taskId },
-                    data: { n_retry: 0 },
+                    data: { n_retry: 0, erro_em: null, erro_mensagem: null },
                 });
             }
 
@@ -639,26 +659,32 @@ export class TaskService {
                 throw lastError;
             }
 
-            // Increment retry count
-            retryCount++;
-            const nextRetryTime = TaskRetryService.calculateNextRetryTime(retryCount, retryConfig);
+            // Acumula a contagem com base no que já foi feito (currentRetryCount), e não em um
+            // contador local — do contrário n_retry ficaria preso em 1 e o retry nunca respeitaria
+            // o limite de maxRetries (loop infinito).
+            const nextRetryCount = currentRetryCount + 1;
+            const nextRetryTime = TaskRetryService.calculateNextRetryTime(nextRetryCount, retryConfig);
 
             this.logger.log(
-                `Task ${taskId} falhou, nova tentativa ${retryCount}/${retryConfig.maxRetries} em ${nextRetryTime.toISOString()}`
+                `Task ${taskId} falhou, nova tentativa ${nextRetryCount}/${retryConfig.maxRetries} em ${nextRetryTime.toISOString()}`
             );
 
-            // Update database with retry information
+            // Reagenda a task (volta para 'pending' com esperar_ate). Mantém a mensagem do erro
+            // para observabilidade enquanto aguarda a próxima tentativa.
             await this.prisma.task_queue.update({
                 where: { id: taskId },
                 data: {
                     status: 'pending',
-                    n_retry: retryCount,
+                    n_retry: nextRetryCount,
                     esperar_ate: nextRetryTime,
+                    erro_em: new Date(),
+                    erro_mensagem: `Retry ${nextRetryCount}/${retryConfig.maxRetries}: ${lastError.message}`,
                 },
             });
 
-            throw new Error(
-                `Retry ${retryCount}/${retryConfig.maxRetries}: ${lastError.message} Task terá nova tentativa em ${nextRetryTime.toISOString()}`
+            // Sinaliza ao chamador que o retry já foi agendado — ele NÃO deve marcar 'errored'.
+            throw new TaskRetryScheduledError(
+                `Retry ${nextRetryCount}/${retryConfig.maxRetries}: ${lastError.message} Task terá nova tentativa em ${nextRetryTime.toISOString()}`
             );
         }
     }


### PR DESCRIPTION
## Contexto

Investigação a partir de dois erros reportados na edição em lote de obras (`/edicoes-em-lote/obras/1000` e `/996`), que se desdobrou na descoberta de problemas estruturais no sistema de tasks (lotes presos em `Executando` para sempre por OOM/SIGKILL). Diagnóstico validado contra produção via Metabase.

## Mudanças

### 1. Edição em lote — `run-update.service.ts`

- **Bug "tarefa null"** (obra 1000): guard contra `value === null` na detecção de `CreateTarefa`. Ao editar Órgão Responsável, o `preprocessOps` injeta um `responsavel_id = null` implícito; como `typeof null === 'object'`, o código acessava `null.tarefa` → `TypeError: Cannot read properties of null (reading 'tarefa')` em **toda** obra (independente de ter cronograma). Confirmado em prod: 50/50 registros com essa exata mensagem.
- **Bug "[object Object]"** (obra 996): novo helper `extrairMensagemErro()` substitui `.getResponse().toString()`, que serializava respostas-objeto de `HttpException` (`{statusCode, message, error}`) como `"[object Object]"`, destruindo a mensagem real na gravação.
- **OOM em lotes grandes**: o stash passa a guardar só o estado anterior das **colunas editadas** (`montaVersaoAnterior`) em vez do objeto `registro` inteiro por linha — que fazia o `task_buffer` crescer sem limite e estourava a memória (SIGKILL). A coluna "Versão Anterior" do relatório Excel continua sendo gerada a partir desse recorte.
- **Retry**: inclui `'Executando'` na lista de status retomáveis do `findUnique`, para um job morto no meio retomar (pulando `sucesso_ids`) em vez de falhar com "não encontrada ou já processada".

### 2. Sistema de tasks — `task.service.ts`

- **Retry de jobs forkados não disparava**: o `.catch` do `handleCron` sobrescrevia o `status='pending'` (agendado pelo `runJob`) para `'errored'`, então o `handleCron` nunca reexecutava. Introduz `TaskRetryScheduledError` para o chamador **não** marcar `'errored'` quando o retry já foi agendado.
- **Contador de retry travado**: `retryCount` era local e resetava a cada chamada, fixando `n_retry` em `1` e nunca respeitando `maxRetries` (loop infinito se o retry disparasse). Passa a acumular via `currentRetryCount + 1`, consistente com o caminho de timeout já existente (`retryTimedOutTask`).

### 3. Reconciliação — `atualizacao-em-lote.service.ts`

- Novo passo periódico (`@Interval`, 10min, gated por `IsCrontabEnabled('task')`) que marca `'Abortado'` toda `AtualizacaoEmLote` presa em `'Executando'` cujo `task_queue` está `'errored'`, e limpa o `task_buffer` órfão. Em prod havia **16 lotes órfãos** segurando **49 MB** de buffer.

### 4. Idempotência de relatório — `reports.service.ts`

- Guard no início de `executaRelatorio`: se `progresso === 100 && processado_em`, pula reprocessamento. Fecha a única janela não-idempotente encontrada na validação de regressão — um retry por OOM poderia regerar o arquivo e **reenviar o e-mail** de conclusão.

## Validação de regressão

O retry é compartilhado por todos os tipos de task. Auditado que a reexecução do zero já era possível via timeout (`retryTimedOutTask`), então todo serviço já tolerava re-run. `runJob` tem caller único; `n_retry` e `task_queue.erro_mensagem` não são lidos por outras features. Todos os tipos (`run_update`, `run_report`, `refresh_*`, preview/thumbnail, backup/restore) revisados quanto a idempotência — único ponto não-idempotente (e-mail de relatório) foi blindado. Retry agora limitado a 3 tentativas com backoff.

## Notas de deploy

- Após o deploy, o passo de reconciliação limpa automaticamente os 16 lotes presos em até 10 min (não é necessário `UPDATE` manual).
- `src/` compila com 0 erros (os erros pré-existentes de `tsc` estão só em `test/`).

## Testes

- [ ] Reprocessar os lotes 1000 e 996 e confirmar sucesso / mensagem de erro legível
- [ ] Verificar reconciliação dos lotes órfãos após o deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of interrupted batch updates, allowing eligible records to resume processing safely.
  * Prevented completed reports from being regenerated or triggering duplicate notifications.
  * Improved retry handling so scheduled retries are preserved and error details remain accurate.
  * Automatically identifies and aborts stalled batches while cleaning up associated task data.
* **Reliability**
  * Added periodic reconciliation to keep background processing consistent after interruptions or failures.
  * Orphaned background workers now exit promptly when their parent process disconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->