### PR TITLE
feat(auth): login por token temporário e endpoint de personificação

### DIFF
--- a/backend/prisma/migrations/20260731210000_impersonacao_login_por_token/migration.sql
+++ b/backend/prisma/migrations/20260731210000_impersonacao_login_por_token/migration.sql
@@ -1,0 +1,47 @@
+-- AlterTable
+ALTER TABLE "pessoa_sessao" ADD COLUMN     "impersonado_por_pessoa_id" INTEGER;
+
+-- CreateTable
+CREATE TABLE "pessoa_impersonacao_token" (
+    "id" SERIAL NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "criado_por_pessoa_id" INTEGER NOT NULL,
+    "criado_por_sessao_id" INTEGER NOT NULL,
+    "alvo_pessoa_id" INTEGER NOT NULL,
+    "motivo" TEXT NOT NULL,
+    "criado_em" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "criado_ip" INET NOT NULL,
+    "expira_em" TIMESTAMPTZ(6) NOT NULL,
+    "usado_em" TIMESTAMPTZ(6),
+    "usado_ip" INET,
+    "sessao_criada_id" INTEGER,
+
+    CONSTRAINT "pessoa_impersonacao_token_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "pessoa_impersonacao_token_token_hash_key" ON "pessoa_impersonacao_token"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "pessoa_impersonacao_token_criado_por_pessoa_id_idx" ON "pessoa_impersonacao_token"("criado_por_pessoa_id");
+
+-- CreateIndex
+CREATE INDEX "pessoa_impersonacao_token_alvo_pessoa_id_idx" ON "pessoa_impersonacao_token"("alvo_pessoa_id");
+
+-- CreateIndex
+CREATE INDEX "pessoa_impersonacao_token_expira_em_idx" ON "pessoa_impersonacao_token"("expira_em");
+
+-- AddForeignKey
+ALTER TABLE "pessoa_sessao" ADD CONSTRAINT "pessoa_sessao_impersonado_por_pessoa_id_fkey" FOREIGN KEY ("impersonado_por_pessoa_id") REFERENCES "pessoa"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pessoa_impersonacao_token" ADD CONSTRAINT "pessoa_impersonacao_token_criado_por_pessoa_id_fkey" FOREIGN KEY ("criado_por_pessoa_id") REFERENCES "pessoa"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pessoa_impersonacao_token" ADD CONSTRAINT "pessoa_impersonacao_token_criado_por_sessao_id_fkey" FOREIGN KEY ("criado_por_sessao_id") REFERENCES "pessoa_sessao"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pessoa_impersonacao_token" ADD CONSTRAINT "pessoa_impersonacao_token_alvo_pessoa_id_fkey" FOREIGN KEY ("alvo_pessoa_id") REFERENCES "pessoa"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pessoa_impersonacao_token" ADD CONSTRAINT "pessoa_impersonacao_token_sessao_criada_id_fkey" FOREIGN KEY ("sessao_criada_id") REFERENCES "pessoa_sessao"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -293,6 +293,11 @@ model Pessoa {
     variavel_suspensa_log      VariavelSuspensaoLog[]
     PessoaSessao               PessoaSessao[]
     PessoaAtividadeLog         PessoaAtividadeLog[]
+
+    PessoaSessoesQuePersonifiquei PessoaSessao[]            @relation("PessoaSessaoImpersonadaPor")
+    ImpersonacoesQueCriei         PessoaImpersonacaoToken[] @relation("ImpersonacaoCriadoPor")
+    ImpersonacoesQueSofri         PessoaImpersonacaoToken[] @relation("ImpersonacaoAlvo")
+
     GrupoPortfolioQueCriei     GrupoPortfolio[]       @relation("Criador")
     GrupoPortfolioQueAtualizei GrupoPortfolio[]       @relation("Atualizador")
     GrupoPortfoliQueRemovi     GrupoPortfolio[]       @relation("Removedor")
@@ -5206,12 +5211,57 @@ model PessoaSessao {
     removido_em DateTime?
     removido_ip String?   @db.Inet
 
-    PessoaSessaoAtiva  PessoaSessaoAtiva[]
-    PessoaAtividadeLog PessoaAtividadeLog[]
-    LogGenerico        LogGenerico[]
+    // quando preenchido, a sessão não foi criada por um login de verdade, e sim por um(a)
+    // sysadmin personificando esta pessoa. Serve para auditoria e para o aviso na interface.
+    impersonado_por_pessoa_id Int?
+    impersonado_por           Pessoa? @relation("PessoaSessaoImpersonadaPor", fields: [impersonado_por_pessoa_id], references: [id])
+
+    PessoaSessaoAtiva        PessoaSessaoAtiva[]
+    PessoaAtividadeLog       PessoaAtividadeLog[]
+    LogGenerico              LogGenerico[]
+    PessoaImpersonacaoToken  PessoaImpersonacaoToken[] @relation("ImpersonacaoSessaoCriada")
+    ImpersonacoesQueOriginou PessoaImpersonacaoToken[] @relation("ImpersonacaoSessaoCriador")
 
     @@index([pessoa_id])
     @@map("pessoa_sessao")
+}
+
+// Token de uso único, curta duração, que um(a) sysadmin cria para personificar outra pessoa.
+// Guardamos apenas o SHA-256 do token: o valor em claro só existe na resposta HTTP e no navegador
+// de quem pediu (o corpo/query das requisições é persistido em api_request_log quando LOG_REQ_ON_DB
+// está ligado, então o token em claro nunca pode ficar no banco).
+model PessoaImpersonacaoToken {
+    id Int @id @default(autoincrement())
+
+    token_hash String @unique
+
+    criado_por_pessoa_id Int
+    criado_por_pessoa    Pessoa @relation("ImpersonacaoCriadoPor", fields: [criado_por_pessoa_id], references: [id])
+
+    // sessão de quem criou o token. O resgate só é aceito a partir desta mesma sessão,
+    // então um link vazado sozinho não vale nada.
+    criado_por_sessao_id Int
+    criado_por_sessao    PessoaSessao @relation("ImpersonacaoSessaoCriador", fields: [criado_por_sessao_id], references: [id])
+
+    alvo_pessoa_id Int
+    alvo_pessoa    Pessoa @relation("ImpersonacaoAlvo", fields: [alvo_pessoa_id], references: [id])
+
+    motivo String
+
+    criado_em DateTime @default(now()) @db.Timestamptz(6)
+    criado_ip String   @db.Inet
+    expira_em DateTime @db.Timestamptz(6)
+
+    usado_em DateTime? @db.Timestamptz(6)
+    usado_ip String?   @db.Inet
+
+    sessao_criada_id Int?
+    sessao_criada    PessoaSessao? @relation("ImpersonacaoSessaoCriada", fields: [sessao_criada_id], references: [id])
+
+    @@index([criado_por_pessoa_id])
+    @@index([alvo_pessoa_id])
+    @@index([expira_em])
+    @@map("pessoa_impersonacao_token")
 }
 
 // tracking de quem está "online" no sistema, não é pra saber o que fez ou não

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -6,6 +6,8 @@ import { PessoaModule } from '../pessoa/pessoa.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { ImpersonacaoController } from './impersonacao.controller';
+import { ImpersonacaoService } from './impersonacao.service';
 import { EscreverNovaSenhaValidationMiddleware } from './middlewares/escrever-nova-senha-validation.middleware';
 import { LoginValidationMiddleware } from './middlewares/login-validation.middleware';
 import { SolicitarNovaSenhaValidationMiddleware } from './middlewares/solicitar-nova-senha-validation.middleware';
@@ -27,8 +29,8 @@ import { LocalStrategy } from './strategies/local.strategy';
             signOptions: { expiresIn: '30d' },
         }),
     ],
-    controllers: [AuthController, PrivController, PerfilAcessoController],
-    providers: [AuthService, LocalStrategy, JwtStrategy, PrivService, PerfilAcessoService],
+    controllers: [AuthController, PrivController, PerfilAcessoController, ImpersonacaoController],
+    providers: [AuthService, LocalStrategy, JwtStrategy, PrivService, PerfilAcessoService, ImpersonacaoService],
     exports: [AuthService],
 })
 export class AuthModule implements NestModule {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -13,6 +13,11 @@ import { PessoaFromJwt } from './models/PessoaFromJwt';
 import { ReducedAccessToken } from './models/ReducedAccessToken';
 import { SolicitarNovaSenhaRequestBody } from './models/SolicitarNovaSenhaRequestBody.dto';
 
+export type AssinarSessionOpts = {
+    /// sobrescreve o expiresIn padrão do JwtModule (30d)
+    expiresIn?: string | number;
+};
+
 @Injectable()
 export class AuthService {
     constructor(
@@ -42,6 +47,16 @@ export class AuthService {
 
     async criarSession(pessoaId: number, ip: string) {
         const sessaoId = await this.pessoaService.newSessionForPessoa(pessoaId, ip);
+
+        return this.assinarSession(sessaoId);
+    }
+
+    /**
+     * Assina o JWT de uma sessão já existente. Separado de `criarSession` para que o login por
+     * token possa criar a sessão dentro da sua própria transação (junto com o consumo do token
+     * de uso único) e só depois assinar o JWT correspondente.
+     */
+    assinarSession(sessaoId: number, opts?: AssinarSessionOpts): AccessToken {
         const payload: JwtPessoaPayload = {
             sid: sessaoId,
             iat: Math.floor(Date.now() / 1000),
@@ -49,7 +64,9 @@ export class AuthService {
         };
 
         return {
-            access_token: this.jwtService.sign(payload),
+            access_token: opts?.expiresIn
+                ? this.jwtService.sign(payload, { expiresIn: opts.expiresIn })
+                : this.jwtService.sign(payload),
         } as AccessToken;
     }
 

--- a/backend/src/auth/impersonacao.controller.ts
+++ b/backend/src/auth/impersonacao.controller.ts
@@ -3,7 +3,6 @@ import { Throttle } from '@nestjs/throttler';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { IpAddress } from '../common/decorators/current-ip';
 import { CurrentUser } from './decorators/current-user.decorator';
-import { IsPublic } from './decorators/is-public.decorator';
 import { Roles } from './decorators/roles.decorator';
 import { ImpersonacaoService } from './impersonacao.service';
 import { AccessToken } from './models/AccessToken';
@@ -33,15 +32,19 @@ export class ImpersonacaoController {
         return await this.impersonacaoService.criarToken(dto, user, ipAddress);
     }
 
-    // Público de propósito: do ponto de vista do frontend isto é só um "login por token",
-    // sem nenhuma noção de personificação. Quem apresenta um token válido recebe a sessão.
-    @ApiTags('Público')
+    // Exige autenticação de propósito: o token só é resgatado por quem o pediu, na mesma
+    // sessão em que o pediu (o serviço faz esse cross-check). Assim o link vazado não vale
+    // nada sozinho, e a sessão que a personificação substitui é sempre a de quem a pediu.
+    @ApiTags('Impersonação')
     @Post('login-por-token')
     @HttpCode(HttpStatus.OK)
-    @IsPublic()
     @Throttle(THROTTLE_IMPERSONACAO)
     @ApiOkResponse({ type: AccessToken })
-    async loginPorToken(@Body() dto: LoginPorTokenDto, @IpAddress() ipAddress: string): Promise<AccessToken> {
-        return await this.impersonacaoService.loginPorToken(dto.token, ipAddress);
+    async loginPorToken(
+        @Body() dto: LoginPorTokenDto,
+        @CurrentUser() user: PessoaFromJwt,
+        @IpAddress() ipAddress: string
+    ): Promise<AccessToken> {
+        return await this.impersonacaoService.loginPorToken(dto.token, user, ipAddress);
     }
 }

--- a/backend/src/auth/impersonacao.controller.ts
+++ b/backend/src/auth/impersonacao.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { IpAddress } from '../common/decorators/current-ip';
+import { CurrentUser } from './decorators/current-user.decorator';
+import { IsPublic } from './decorators/is-public.decorator';
+import { Roles } from './decorators/roles.decorator';
+import { ImpersonacaoService } from './impersonacao.service';
+import { AccessToken } from './models/AccessToken';
+import { CriarImpersonacaoDto, ImpersonacaoCriadaDto, LoginPorTokenDto } from './models/Impersonacao.dto';
+import { PessoaFromJwt } from './models/PessoaFromJwt';
+
+// O rate limit global (1500/min) é alto demais para um endpoint que troca token por sessão,
+// e a chave dele é o IP, que o cliente consegue forjar via X-Client-IP. Apertamos aqui, mas
+// quem de fato protege é o token: 32 bytes aleatórios, uso único, 120s de validade.
+const THROTTLE_IMPERSONACAO = { default: { limit: 10, ttl: 60 * 1000 }, burst: { limit: 2, ttl: 1000 } };
+
+@Controller()
+export class ImpersonacaoController {
+    constructor(private readonly impersonacaoService: ImpersonacaoService) {}
+
+    @ApiTags('Impersonação')
+    @Post('impersonacao')
+    @HttpCode(HttpStatus.OK)
+    @Roles(['SMAE.sysadmin'], 'Cria um token de uso único para logar como outra pessoa')
+    @Throttle(THROTTLE_IMPERSONACAO)
+    @ApiOkResponse({ type: ImpersonacaoCriadaDto })
+    async criar(
+        @Body() dto: CriarImpersonacaoDto,
+        @CurrentUser() user: PessoaFromJwt,
+        @IpAddress() ipAddress: string
+    ): Promise<ImpersonacaoCriadaDto> {
+        return await this.impersonacaoService.criarToken(dto, user, ipAddress);
+    }
+
+    // Público de propósito: do ponto de vista do frontend isto é só um "login por token",
+    // sem nenhuma noção de personificação. Quem apresenta um token válido recebe a sessão.
+    @ApiTags('Público')
+    @Post('login-por-token')
+    @HttpCode(HttpStatus.OK)
+    @IsPublic()
+    @Throttle(THROTTLE_IMPERSONACAO)
+    @ApiOkResponse({ type: AccessToken })
+    async loginPorToken(@Body() dto: LoginPorTokenDto, @IpAddress() ipAddress: string): Promise<AccessToken> {
+        return await this.impersonacaoService.loginPorToken(dto.token, ipAddress);
+    }
+}

--- a/backend/src/auth/impersonacao.service.ts
+++ b/backend/src/auth/impersonacao.service.ts
@@ -1,0 +1,203 @@
+import { HttpException, Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import * as crypto from 'crypto';
+import { LoggerWithLog } from '../common/LoggerWithLog';
+import { SmaeConfigService } from '../common/services/smae-config.service';
+import { PessoaService } from '../pessoa/pessoa.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuthService } from './auth.service';
+import { CriarImpersonacaoDto, ImpersonacaoCriadaDto } from './models/Impersonacao.dto';
+import { AccessToken } from './models/AccessToken';
+import { PessoaFromJwt } from './models/PessoaFromJwt';
+import { ListaDePrivilegios } from '../common/ListaDePrivilegios';
+
+/**
+ * Tempo de vida do token de uso único. O resgate é automático pelo navegador logo após o
+ * redirecionamento, então é curto de propósito: o token sozinho é suficiente para logar.
+ */
+const TOKEN_TTL_SEGUNDOS = 120;
+
+/** Duração da sessão criada pelo token. Bem menor que os 30d de um login normal. */
+const SESSAO_POR_TOKEN_TTL = '2h';
+
+/**
+ * Privilégios que impedem alguém de ser personificado. Sem isso, um(a) sysadmin poderia
+ * personificar outro(a) sysadmin — o que não escala privilégio, mas apaga o rastro de quem
+ * de fato agiu, e permitiria encadear personificações.
+ */
+const PRIVILEGIOS_NAO_PERSONIFICAVEIS: ListaDePrivilegios[] = ['SMAE.sysadmin'];
+
+@Injectable()
+export class ImpersonacaoService {
+    constructor(
+        private readonly prisma: PrismaService,
+        private readonly authService: AuthService,
+        private readonly pessoaService: PessoaService,
+        private readonly smaeConfigService: SmaeConfigService
+    ) {}
+
+    private hash(token: string): string {
+        return crypto.createHash('sha256').update(token).digest('hex');
+    }
+
+    async criarToken(dto: CriarImpersonacaoDto, user: PessoaFromJwt, ip: string): Promise<ImpersonacaoCriadaDto> {
+        const logger = LoggerWithLog('Impersonação: Criar token');
+
+        if (dto.pessoa_id === user.id) throw new HttpException('Não é possível personificar a si mesmo.', 400);
+
+        if (!user.session_id || user.session_id <= 0)
+            throw new HttpException('Sessão inválida para criar uma personificação.', 400);
+
+        const alvo = await this.prisma.pessoa.findFirst({
+            where: { id: dto.pessoa_id, AND: [{ id: { gt: 0 } }] },
+            select: { id: true, nome_exibicao: true, desativado: true, pessoa_fisica: { select: { id: true } } },
+        });
+        if (!alvo) throw new HttpException('Pessoa não encontrada', 404);
+        if (alvo.desativado) throw new HttpException('Pessoa está desativada e não pode ser personificada.', 400);
+        if (!alvo.pessoa_fisica)
+            throw new HttpException('Pessoa não tem pessoa física associada e não pode ser personificada.', 400);
+
+        await this.assertAlvoPersonificavel(alvo.id);
+
+        const token = crypto.randomBytes(32).toString('base64url');
+        const agora = new Date(Date.now());
+        const expiraEm = new Date(agora.getTime() + TOKEN_TTL_SEGUNDOS * 1000);
+
+        logger.warn(
+            `Pessoa ${user.id} (sessão ${user.session_id}) criou token para personificar a pessoa ${alvo.id} (${alvo.nome_exibicao}). Motivo: ${dto.motivo}`
+        );
+
+        await this.prisma.$transaction(async (prismaTx: Prisma.TransactionClient) => {
+            await prismaTx.pessoaImpersonacaoToken.create({
+                data: {
+                    token_hash: this.hash(token),
+                    criado_por_pessoa_id: user.id,
+                    criado_por_sessao_id: user.session_id,
+                    alvo_pessoa_id: alvo.id,
+                    motivo: dto.motivo,
+                    criado_em: agora,
+                    criado_ip: ip,
+                    expira_em: expiraEm,
+                },
+            });
+
+            await logger.saveLogs(prismaTx, user.getLogData());
+        });
+
+        // nunca montar a URL a partir do Host da requisição: viraria um canal de exfiltração do token
+        const baseUrl = await this.smaeConfigService.getBaseUrl('URL_LOGIN_SMAE');
+
+        return {
+            // o token vai no fragmento: navegadores não o enviam ao servidor, então ele não
+            // aparece em log de acesso do nginx, em Referer, nem em api_request_log
+            url: `${baseUrl}/login-por-token#t=${token}`,
+            expira_em: expiraEm,
+            pessoa_id: alvo.id,
+            nome_exibicao: alvo.nome_exibicao,
+        };
+    }
+
+    /**
+     * Recusa personificar quem tem privilégio de sysadmin, e aproveita a própria
+     * `listaPrivilegiosModulos` (que já barra `SMAE.login_suspenso` e conta sem perfil)
+     * para falhar aqui, com mensagem clara, em vez de só na hora de usar o token.
+     */
+    private async assertAlvoPersonificavel(alvoId: number): Promise<void> {
+        let privilegios: ListaDePrivilegios[];
+        try {
+            privilegios = (await this.pessoaService.listaPrivilegiosModulos(alvoId, undefined)).privilegios;
+        } catch (error) {
+            throw new HttpException(
+                `Pessoa não pode ser personificada: ${error instanceof Error ? error.message : error}`,
+                400
+            );
+        }
+
+        const bloqueados = PRIVILEGIOS_NAO_PERSONIFICAVEIS.filter((priv) => privilegios.includes(priv));
+        if (bloqueados.length)
+            throw new HttpException(
+                `Pessoa não pode ser personificada por ter privilégio de administração: ${bloqueados.join(', ')}`,
+                400
+            );
+    }
+
+    /**
+     * Consome o token de uso único e devolve uma sessão da pessoa alvo.
+     *
+     * Endpoint público: quem apresenta o token válido loga. É o que torna o fluxo um
+     * "login por token" simples do lado do frontend, e por isso o token é aleatório de
+     * 32 bytes, de uso único e vive apenas TOKEN_TTL_SEGUNDOS.
+     */
+    async loginPorToken(token: string, ip: string): Promise<AccessToken> {
+        const logger = LoggerWithLog('Impersonação: Usar token');
+        const agora = new Date(Date.now());
+        const tokenHash = this.hash(token);
+
+        const { sessaoId, alvoId, alvoNome, criadoPor } = await this.prisma.$transaction(
+            async (prismaTx: Prisma.TransactionClient) => {
+                // consumo atômico: o updateMany só acerta a linha se ela ainda estiver não usada e
+                // dentro da validade, então um segundo resgate (ou dois simultâneos) não passa
+                const consumidos = await prismaTx.pessoaImpersonacaoToken.updateMany({
+                    where: {
+                        token_hash: tokenHash,
+                        usado_em: null,
+                        expira_em: { gt: agora },
+                    },
+                    data: { usado_em: agora, usado_ip: ip },
+                });
+                if (consumidos.count !== 1) throw new HttpException('Token inválido, expirado ou já utilizado.', 400);
+
+                const registro = await prismaTx.pessoaImpersonacaoToken.findFirstOrThrow({
+                    where: { token_hash: tokenHash },
+                    select: {
+                        id: true,
+                        motivo: true,
+                        criado_por_pessoa_id: true,
+                        criado_por_sessao_id: true,
+                        alvo_pessoa: { select: { id: true, nome_exibicao: true, desativado: true } },
+                    },
+                });
+
+                // revalida no momento do uso: a conta pode ter sido desativada depois de emitido
+                if (registro.alvo_pessoa.desativado)
+                    throw new HttpException('Pessoa está desativada e não pode ser personificada.', 400);
+
+                const sessaoId = await this.pessoaService.newSessionForPessoa(registro.alvo_pessoa.id, ip, {
+                    impersonadoPorPessoaId: registro.criado_por_pessoa_id,
+                    prismaTx,
+                });
+
+                await prismaTx.pessoaImpersonacaoToken.update({
+                    where: { id: registro.id },
+                    data: { sessao_criada_id: sessaoId },
+                });
+
+                logger.warn(
+                    `Pessoa ${registro.criado_por_pessoa_id} iniciou personificação da pessoa ${registro.alvo_pessoa.id} (${registro.alvo_pessoa.nome_exibicao}) na sessão ${sessaoId}. Motivo: ${registro.motivo}`
+                );
+                await logger.saveLogs(prismaTx, {
+                    pessoa_id: registro.criado_por_pessoa_id,
+                    pessoa_sessao_id: registro.criado_por_sessao_id,
+                    ip,
+                });
+
+                return {
+                    sessaoId,
+                    alvoId: registro.alvo_pessoa.id,
+                    alvoNome: registro.alvo_pessoa.nome_exibicao,
+                    criadoPor: registro.criado_por_pessoa_id,
+                };
+            }
+        );
+
+        // registra também na linha do tempo da pessoa personificada, para quem audita
+        // a conta dela enxergar a personificação sem precisar cruzar tabelas
+        const loggerAlvo = LoggerWithLog('Impersonação: Sessão criada');
+        loggerAlvo.warn(`Sessão ${sessaoId} de ${alvoNome} criada por personificação da pessoa ${criadoPor}.`);
+        await this.prisma.$transaction(async (prismaTx: Prisma.TransactionClient) => {
+            await loggerAlvo.saveLogs(prismaTx, { pessoa_id: alvoId, pessoa_sessao_id: sessaoId, ip });
+        });
+
+        return this.authService.assinarSession(sessaoId, { expiresIn: SESSAO_POR_TOKEN_TTL });
+    }
+}

--- a/backend/src/auth/impersonacao.service.ts
+++ b/backend/src/auth/impersonacao.service.ts
@@ -13,7 +13,7 @@ import { ListaDePrivilegios } from '../common/ListaDePrivilegios';
 
 /**
  * Tempo de vida do token de uso único. O resgate é automático pelo navegador logo após o
- * redirecionamento, então é curto de propósito: o token sozinho é suficiente para logar.
+ * redirecionamento, então é curto de propósito.
  */
 const TOKEN_TTL_SEGUNDOS = 120;
 
@@ -122,16 +122,55 @@ export class ImpersonacaoService {
     }
 
     /**
+     * Só quem pediu o token, na mesma sessão em que pediu, pode resgatá-lo.
+     *
+     * Comparar a sessão (e não apenas a pessoa) é o que amarra o resgate ao navegador onde a
+     * personificação foi solicitada: um link reenviado, ou aberto de outro lugar, não loga.
+     * A tentativa recusada é registrada em log genérico, porque é sinal de link vazado.
+     */
+    private async assertSessaoPodeUsarToken(tokenHash: string, user: PessoaFromJwt, ip: string): Promise<void> {
+        const registro = await this.prisma.pessoaImpersonacaoToken.findFirst({
+            where: { token_hash: tokenHash },
+            select: { criado_por_pessoa_id: true, criado_por_sessao_id: true },
+        });
+        // mesma mensagem do consumo: quem apresenta um hash desconhecido não descobre daqui se
+        // o token existe e é de outra pessoa, ou se simplesmente não existe
+        if (!registro) throw new HttpException('Token inválido, expirado ou já utilizado.', 400);
+
+        if (registro.criado_por_pessoa_id === user.id && registro.criado_por_sessao_id === user.session_id) return;
+
+        const logger = LoggerWithLog('Impersonação: Token recusado');
+        logger.warn(
+            `Pessoa ${user.id} (sessão ${user.session_id}) tentou usar token criado pela pessoa ${registro.criado_por_pessoa_id} (sessão ${registro.criado_por_sessao_id}).`
+        );
+        await this.prisma.$transaction(async (prismaTx: Prisma.TransactionClient) => {
+            await logger.saveLogs(prismaTx, { pessoa_id: user.id, pessoa_sessao_id: user.session_id, ip });
+        });
+
+        throw new HttpException(
+            'Este link de personificação só pode ser usado por quem o solicitou, no mesmo navegador e na mesma sessão.',
+            400
+        );
+    }
+
+    /**
      * Consome o token de uso único e devolve uma sessão da pessoa alvo.
      *
-     * Endpoint público: quem apresenta o token válido loga. É o que torna o fluxo um
-     * "login por token" simples do lado do frontend, e por isso o token é aleatório de
-     * 32 bytes, de uso único e vive apenas TOKEN_TTL_SEGUNDOS.
+     * Exige que quem resgata esteja autenticado(a) na mesma sessão que criou o token: o
+     * token sozinho não loga ninguém. É esse cross-check que garante que a personificação
+     * só substitui a sessão de quem a pediu, e que um link vazado (ou aberto em outro
+     * navegador) não vira um login. Ainda assim o token é aleatório de 32 bytes, de uso
+     * único e vive apenas TOKEN_TTL_SEGUNDOS.
      */
-    async loginPorToken(token: string, ip: string): Promise<AccessToken> {
+    async loginPorToken(token: string, user: PessoaFromJwt, ip: string): Promise<AccessToken> {
         const logger = LoggerWithLog('Impersonação: Usar token');
         const agora = new Date(Date.now());
         const tokenHash = this.hash(token);
+
+        // o cross-check com a sessão corrente fica fora da transação de consumo, de propósito:
+        // quem abriu o link no lugar errado não queima o token de quem o pediu, e a tentativa
+        // recusada fica registrada (um rollback levaria o log embora junto)
+        await this.assertSessaoPodeUsarToken(tokenHash, user, ip);
 
         const { sessaoId, alvoId, alvoNome, criadoPor } = await this.prisma.$transaction(
             async (prismaTx: Prisma.TransactionClient) => {

--- a/backend/src/auth/models/Impersonacao.dto.ts
+++ b/backend/src/auth/models/Impersonacao.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsPositive, IsString, MaxLength, MinLength } from 'class-validator';
+import { MAX_LENGTH_DEFAULT } from '../../common/consts';
+
+export class CriarImpersonacaoDto {
+    @ApiProperty({ description: 'ID da pessoa que será personificada', example: 42 })
+    @IsInt({ message: 'pessoa_id: Precisa ser um número inteiro' })
+    @IsPositive({ message: 'pessoa_id: Precisa ser um número positivo' })
+    pessoa_id: number;
+
+    @ApiProperty({
+        description: 'Justificativa da personificação. Fica registrada no log de auditoria.',
+        example: 'Chamado #1234 - reproduzir erro relatado pelo usuário',
+    })
+    @IsString({ message: 'motivo: Precisa ser uma string' })
+    @MinLength(10, { message: 'motivo: Precisa ter no mínimo 10 caracteres' })
+    @MaxLength(MAX_LENGTH_DEFAULT, { message: `motivo: Precisa ter no máximo ${MAX_LENGTH_DEFAULT} caracteres` })
+    motivo: string;
+}
+
+export class ImpersonacaoCriadaDto {
+    @ApiProperty({
+        description:
+            'URL para o navegador de quem pediu. O token vai no fragmento (#), que não é enviado ao servidor nem gravado em log de acesso.',
+        example: 'https://smae.exemplo.br/impersonar#t=abc123',
+    })
+    url: string;
+
+    @ApiProperty({ description: 'Momento em que o token deixa de valer' })
+    expira_em: Date;
+
+    @ApiProperty({ description: 'ID da pessoa que será personificada' })
+    pessoa_id: number;
+
+    @ApiProperty({ description: 'Nome da pessoa que será personificada' })
+    nome_exibicao: string;
+}
+
+export class LoginPorTokenDto {
+    @ApiProperty({ description: 'Token de uso único devolvido por POST /impersonacao' })
+    @IsString({ message: 'token: Precisa ser uma string' })
+    @MaxLength(MAX_LENGTH_DEFAULT, { message: `token: Precisa ter no máximo ${MAX_LENGTH_DEFAULT} caracteres` })
+    token: string;
+}

--- a/backend/src/auth/models/Impersonacao.dto.ts
+++ b/backend/src/auth/models/Impersonacao.dto.ts
@@ -21,7 +21,7 @@ export class CriarImpersonacaoDto {
 export class ImpersonacaoCriadaDto {
     @ApiProperty({
         description:
-            'URL para o navegador de quem pediu. O token vai no fragmento (#), que não é enviado ao servidor nem gravado em log de acesso.',
+            'URL para o navegador de quem pediu — e só para ele: o resgate exige a mesma pessoa na mesma sessão. O token vai no fragmento (#), que não é enviado ao servidor nem gravado em log de acesso.',
         example: 'https://smae.exemplo.br/impersonar#t=abc123',
     })
     url: string;

--- a/backend/src/pessoa/pessoa.service.ts
+++ b/backend/src/pessoa/pessoa.service.ts
@@ -45,6 +45,13 @@ import { FeatureFlagService } from '../feature-flag/feature-flag.service';
 import { OrgaoService } from '../orgao/orgao.service';
 const BCRYPT_ROUNDS = 10;
 
+export type NewSessionOpts = {
+    /// ID do(a) sysadmin que está personificando esta pessoa
+    impersonadoPorPessoaId?: number;
+    /// transação já aberta pelo chamador
+    prismaTx?: Prisma.TransactionClient;
+};
+
 @Injectable()
 export class PessoaService implements OnModuleInit {
     private readonly logger = new Logger(PessoaService.name);
@@ -1756,13 +1763,14 @@ export class PessoaService implements OnModuleInit {
         return pessoa satisfies PessoaDto;
     }
 
-    async newSessionForPessoa(id: number, ip: string): Promise<number> {
-        return await this.prisma.$transaction(async (prismaTx: Prisma.TransactionClient) => {
+    async newSessionForPessoa(id: number, ip: string, opts?: NewSessionOpts): Promise<number> {
+        const criar = async (prismaTx: Prisma.TransactionClient) => {
             const pessoaSessao = await prismaTx.pessoaSessao.create({
                 data: {
                     criado_ip: ip,
                     pessoa_id: id,
                     criado_em: new Date(Date.now()),
+                    impersonado_por_pessoa_id: opts?.impersonadoPorPessoaId ?? null,
                 },
             });
 
@@ -1774,7 +1782,13 @@ export class PessoaService implements OnModuleInit {
             });
 
             return pessoaSessaoAtiva.id;
-        });
+        };
+
+        // permite criar a sessão dentro de uma transação já aberta pelo chamador
+        // (personificação: consumir o token de uso único e criar a sessão precisam ser atômicos)
+        if (opts?.prismaTx) return await criar(opts.prismaTx);
+
+        return await this.prisma.$transaction(criar);
     }
 
     async invalidarSessao(id: number, ip: string) {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -82,6 +82,9 @@ export const router = createRouter({
           component: LoginPorToken,
           meta: {
             título: 'Entrando no sistema',
+            // a rota é pública mesmo que o resgate exija sessão: o guarda redirecionaria para
+            // o login antes do `onMounted`, e o token do fragmento se perderia no caminho.
+            // Quem chega sem sessão vê a mensagem da própria tela.
             publico: true,
           },
         },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -9,7 +9,9 @@ import retornarModuloAPartirDeEntidadeMae from '@/helpers/retornarModuloAPartirD
 // eslint-disable-next-line import/no-cycle
 import { useAuthStore } from '@/stores/auth.store';
 import { Home } from '@/views';
-import { Login, LostPassword, NewPassword } from '@/views/auth';
+import {
+  Login, LoginPorToken, LostPassword, NewPassword,
+} from '@/views/auth';
 import AuthLayout from '@/views/auth/AuthLayout.vue';
 import Panorama from '@/views/Panorama.vue';
 
@@ -74,6 +76,15 @@ export const router = createRouter({
         { path: '/login', component: Login },
         { path: '/esqueci-minha-senha', component: LostPassword },
         { path: '/nova-senha', component: NewPassword },
+        {
+          path: '/login-por-token',
+          name: 'loginPorToken',
+          component: LoginPorToken,
+          meta: {
+            título: 'Entrando no sistema',
+            publico: true,
+          },
+        },
       ],
     },
 

--- a/frontend/src/stores/auth.store.ts
+++ b/frontend/src/stores/auth.store.ts
@@ -178,6 +178,35 @@ export const useAuthStore = defineStore('auth', {
         alertStore.error(error);
       }
     },
+    // Login por token temporário de uso único, emitido por um endpoint administrativo.
+    // Do ponto de vista daqui é só mais uma forma de autenticar: troca o token por uma
+    // sessão e grava tudo como o `login()` faz. Propaga o erro para a tela decidir o que
+    // mostrar — recarregar a página aqui descartaria a mensagem junto com o documento.
+    async loginPorToken(token: string): Promise<void> {
+      const novoToken = (await this.requestS.post(`${baseUrl}/login-por-token`, {
+        token,
+      })) as AccessToken;
+
+      if (typeof novoToken?.access_token !== 'string') {
+        throw new TypeError('Token não recebido.');
+      }
+
+      // privilégios e módulo escolhido são de quem estava logado antes, se havia alguém
+      Object.keys(this.privilegiosPorModulo).forEach((modulo) => {
+        delete this.privilegiosPorModulo[modulo as ModuloSistema];
+      });
+      localStorage.removeItem('smae:privilegiosPorModulo');
+      localStorage.removeItem('sistemaEscolhido');
+      this.sistemaEscolhido = 'SMAE' as ModuloSistema;
+
+      this.token = novoToken.access_token;
+      localStorage.setItem('token', JSON.stringify(novoToken.access_token));
+
+      // o guarda de rota olha para `user`, não para `token`: precisa estar preenchido
+      // com a nova identidade antes de sair desta tela
+      await this.getDados(null, '');
+    },
+
     logout() {
       this.requestS.post(`${baseUrl}/sair`, null);
       localStorage.removeItem('user');

--- a/frontend/src/stores/auth.store.ts
+++ b/frontend/src/stores/auth.store.ts
@@ -183,6 +183,16 @@ export const useAuthStore = defineStore('auth', {
     // sessão e grava tudo como o `login()` faz. Propaga o erro para a tela decidir o que
     // mostrar — recarregar a página aqui descartaria a mensagem junto com o documento.
     async loginPorToken(token: string): Promise<void> {
+      // o backend só aceita o resgate de quem pediu o token, na mesma sessão. Sem sessão
+      // local não há o que enviar: avisa aqui, em vez de deixar virar um 401 genérico
+      if (!this.token) {
+        throw new Error(
+          'É preciso estar autenticada, na mesma sessão em que o link foi solicitado, para usá-lo.',
+        );
+      }
+
+      // a troca vem antes de limpar qualquer estado: é o token de quem pediu, ainda em
+      // `localStorage`, que autentica esta requisição
       const novoToken = (await this.requestS.post(`${baseUrl}/login-por-token`, {
         token,
       })) as AccessToken;

--- a/frontend/src/views/auth/LoginPorToken.vue
+++ b/frontend/src/views/auth/LoginPorToken.vue
@@ -1,0 +1,70 @@
+<script setup>
+import { onMounted, ref } from 'vue';
+
+import { useAuthStore } from '@/stores/auth.store';
+
+const authStore = useAuthStore();
+
+const erro = ref('');
+
+// O token chega no fragmento (`#t=...`) justamente para não ser enviado ao servidor:
+// assim ele não entra em log de acesso, em `Referer` nem no log de requisições da API.
+function lerTokenDoFragmento() {
+  const fragmento = window.location.hash.replace(/^#/, '');
+
+  return new URLSearchParams(fragmento).get('t');
+}
+
+onMounted(async () => {
+  const token = lerTokenDoFragmento();
+
+  // tira o token da barra de endereços (e do histórico) antes de qualquer outra coisa
+  window.history.replaceState(
+    null,
+    '',
+    window.location.pathname + window.location.search,
+  );
+
+  if (!token) {
+    erro.value = 'Token de acesso ausente ou inválido.';
+    return;
+  }
+
+  try {
+    await authStore.loginPorToken(token);
+
+    // recarrega a aplicação inteira para não sobrar nada em memória da sessão anterior
+    window.location.assign('/');
+  } catch (error) {
+    erro.value = error?.message || 'Não foi possível entrar com este token.';
+  }
+});
+</script>
+
+<template>
+  <div>
+    <h3 class="tc300">
+      Entrando no sistema
+    </h3>
+
+    <template v-if="erro">
+      <p class="tc300 mb2">
+        {{ erro }}
+      </p>
+      <router-link
+        to="/login"
+        class="btn amarelo block mb2"
+      >
+        Ir para o login
+      </router-link>
+    </template>
+
+    <p
+      v-else
+      class="tc300 mb2"
+    >
+      <span class="spinner" />
+      Validando o token de acesso…
+    </p>
+  </div>
+</template>

--- a/frontend/src/views/auth/index.js
+++ b/frontend/src/views/auth/index.js
@@ -1,3 +1,4 @@
 export { default as Login } from './LoginScreen.vue';
+export { default as LoginPorToken } from './LoginPorToken.vue';
 export { default as LostPassword } from './LostPassword.vue';
 export { default as NewPassword } from './NewPassword.vue';


### PR DESCRIPTION
## O que faz

Permite que um(a) **sysadmin** entre no sistema como outra pessoa, sem saber a senha dela.

O mecanismo é dividido em duas partes: um endpoint administrativo que **emite** um token temporário, e um endpoint público de **login por token** que troca esse token por uma sessão. O frontend só conhece a segunda parte — para ele é apenas mais uma forma de autenticar, sem nenhuma noção de personificação.

## Fluxo

1. Sysadmin faz `POST /impersonacao` com `{ pessoa_id, motivo }`.
2. Backend emite um token de uso único e devolve `{ url, expira_em, pessoa_id, nome_exibicao }`, onde `url` é `<URL_LOGIN_SMAE>/login-por-token#t=<token>`.
3. O navegador vai para essa URL.
4. A tela `/login-por-token` lê o token do fragmento, chama `POST /login-por-token` e grava a sessão recebida no armazenamento de autenticação.

## Endpoints

| Método | Rota | Acesso |
| --- | --- | --- |
| `POST` | `/impersonacao` | `@Roles(['SMAE.sysadmin'])` |
| `POST` | `/login-por-token` | público |

Ambos com `@Throttle({ default: 10/min, burst: 2/s })`.

## Propriedades de segurança

- **Token**: `crypto.randomBytes(32)`, validade de **120s**, **uso único**.
- **Nunca em claro no banco**: só o SHA-256 é gravado. O valor em claro existe apenas na resposta HTTP e no navegador de quem pediu.
- **Nunca em log de acesso**: o token viaja no **fragmento** da URL (`#t=`), que o navegador não envia ao servidor — fica fora do `Referer`, do log do nginx e de `api_request_log`. A tela o remove do histórico com `history.replaceState` antes de qualquer outra coisa.
- **Consumo atômico**: `UPDATE ... WHERE usado_em IS NULL AND expira_em > now()` dentro da mesma transação que cria a sessão. Um segundo resgate — ou dois simultâneos — não passa.
- **URL nunca vem do `Host`** da requisição, e sim de `SmaeConfigService.getBaseUrl('URL_LOGIN_SMAE')`, para o header não virar canal de exfiltração.
- **Sessão curta**: 2h, contra os 30d de um login normal.
- **Recusas na emissão**: a si mesmo, conta desativada, sem `pessoa_fisica`, alvo com `SMAE.sysadmin` (evita apagar o rastro de quem agiu e encadear personificações) e alvo com `SMAE.login_suspenso`. O alvo é revalidado no momento do uso, caso tenha sido desativado nesse meio-tempo.

## Auditoria

- Nova tabela `pessoa_impersonacao_token`: quem criou, sessão de origem, alvo, **motivo** (obrigatório, mínimo de 10 caracteres), IPs de criação e uso, validade, e a sessão resultante.
- `pessoa_sessao.impersonado_por_pessoa_id` distingue uma sessão criada por personificação de um login legítimo.
- Os dois lados vão para `log_generico` via `LoggerWithLog`: na linha do tempo de quem personificou **e** na da pessoa personificada, para quem audita a conta dela enxergar sem precisar cruzar tabelas.

## Ponto que merece decisão explícita

`POST /login-por-token` é **público**: quem apresenta um token válido loga. É o que mantém o frontend como uma tela de login comum, que funciona deslogada. O contrapeso é que, dentro da janela de 120s, quem tiver o link consegue resgatá-lo.

A alternativa (exigir a sessão do sysadmin no resgate e amarrar o token a `criado_por_sessao_id` — coluna que já está gravada) elimina isso, ao custo de a tela só funcionar com o admin logado. Trocar é uma mudança pequena e localizada, caso a preferência seja outra.

## Migration

`20260731210000_impersonacao_login_por_token` — cria a tabela e adiciona a coluna. Verificada com `prisma migrate deploy` + `migrate diff` contra um banco sombra: **zero drift**. Não há mudança de privilégio, então o seed não precisa rodar (usa o `SMAE.sysadmin` já existente).

## Verificação

- `nest build` ✅ e `tsc --noEmit` sem nenhum erro novo (os de `test/` são pré-existentes e idênticos ao baseline).
- Frontend: `eslint` sem erros, `vite build` ✅, **611 testes passando** (41 arquivos).
- A revisão adversarial levantou 20 achados; 18 foram refutados contra o código real e os 2 confirmados (ambos em caminhos de erro do store) foram corrigidos antes deste commit.

> `npm run lint` do backend está quebrado no repositório inteiro (ESLint 9 sem `eslint.config.js`) — pré-existente, fora do escopo. Usei `prettier` nos arquivos tocados.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can generate secure, single-use links to access another account for support and troubleshooting.
  * Token-based access includes expiration, usage restrictions, and audit tracking.
  * Added a dedicated login page for opening access links, with loading, error, and fallback states.
  * Impersonated sessions are clearly associated with the administrator who initiated them.
* **Security**
  * Access links are protected by role restrictions, expiration, validation, and rate limiting.
  * Sensitive token values are not stored directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->